### PR TITLE
[ci skip] Add SaltyEmu as a community example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ There's currently no official documentation for Qmmands other than the usage exa
 * [Kiritsu](https://github.com/Kiritsu)'s Discord bot: [FoxBot](https://github.com/Kiritsu/FoxBot) (DSharpPlus)
 * [GreemDev](https://github.com/GreemDev)'s Discord bot: [Volte](https://github.com/GreemDev/Volte) (Discord.Net)
 * [TheCasino](https://github.com/TheCasino)'s Discord bot: [Espeon](https://github.com/TheCasino/Espeon) (Discord.Net)
+* [BlowaXD](https://github.com/BlowaXD)'s Nostale Server Emulator: [SaltyEmu](https://github.com/BlowaXD/SaltyEmu) 
 
 ### A Simple Usage Example
 **CommandHandler.cs**


### PR DESCRIPTION
Hi,

I'd like to add [SaltyEmu](https://github.com/BlowaXD/SaltyEmu) (an MMORPG server Emulator) as another community example which is not a Discord Bot 

Regards,
Blowa.