### PR TITLE
Refactored various parts of code (3.0).

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ private async Task MessageReceivedAsync(Message message)
         await message.Channel.SendMessageAsync(failedResult.Reason); 
 }
 ```
-**CommandContext.cs**
+**CustomCommandContext.cs**
 ```cs
-public sealed class CommandContext : ICommandContext
+public sealed class CustomCommandContext : CommandContext
 {
     public Message Message { get; }
     
@@ -61,8 +61,11 @@ public sealed class CommandContext : ICommandContext
 ```
 **CommandModule.cs**
 ```cs
-public sealed class CommandModule : ModuleBase<CommandContext>
+public sealed class CommandModule : ModuleBase<CustomCommandContext>
 {
+    // Dependency Injection via a constructor or public settable properties.
+    // CommandService and IServiceProvider self-inject into modules,
+    // properties and other types are requested from the provided IServiceProvider
     public CommandService Service { get; set; }
 
     // Invoked with:   !help

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ private async Task MessageReceivedAsync(Message message)
     if (!CommandUtilities.HasPrefix(message.Content, '!', out string output))
         return;
         
-    IResult result = await _service.ExecuteAsync(output, new CommandContext(message));
+    IResult result = await _service.ExecuteAsync(output, new CustomCommandContext(message));
     if (result is FailedResult failedResult)
         await message.Channel.SendMessageAsync(failedResult.Reason); 
 }

--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@
 [![MyGet](https://img.shields.io/myget/qmmands/vpre/Qmmands.svg?style=flat-square&label=myget)](https://www.myget.org/gallery/qmmands)
 [![The Lab](https://img.shields.io/discord/416256456505950215.svg?style=flat-square&label=discord)](https://discord.gg/eUMSXGZ)  
 
-An asynchronous platform-independent .NET Standard 2.0 command framework that can be used with any input source, whether that be Discord messages, IRC, or a terminal. 
+An asynchronous platform-independent .NET Standard 2.0 and .NET Core 2.1-2.2 command framework that can be used with any input source, whether that be Discord messages, IRC, or a terminal. 
 
 Inspired by [Discord.Net.Commands](https://github.com/RogueException/Discord.Net/tree/dev/src/Discord.Net.Commands) and [DSharpPlus.CommandsNext](https://github.com/DSharpPlus/DSharpPlus/tree/master/DSharpPlus.CommandsNext).
 
-Qmmands can be pulled from NuGet. For nightly builds add `https://www.myget.org/F/qmmands/api/v3/index.json` (the nightly feed) to your project's package sources.
+
+## Installing
+Stable Qmmands builds can be pulled from NuGet.
+For nightly builds add `https://www.myget.org/F/quahu/api/v3/index.json` (the nightly feed) to your project's package sources.
+
 
 ## Key Features
 - Advanced parameter parsing support (including custom type parsers, optional parameters, and remainder support)
@@ -19,14 +23,14 @@ Qmmands can be pulled from NuGet. For nightly builds add `https://www.myget.org/
 
 
 ## Documentation
-There's currently no official documentation for Qmmands other than the usage examples below and the bundled XML docstrings. For support you should hop in my Discord guild:
+There's currently no official documentation for Qmmands other than the community projects below and the bundled XML docstrings. For support you should hop in my Discord guild:
 
 [![The Lab](https://discordapp.com/api/guilds/416256456505950215/embed.png?style=banner2)](https://discord.gg/eUMSXGZ)
 
 
-### Community Examples:
+### Community Projects:
 * [Kiritsu](https://github.com/Kiritsu)'s Discord bot: [FoxBot](https://github.com/Kiritsu/FoxBot) (DSharpPlus)
-* [GreemDev](https://github.com/GreemDev)'s Discord bot: [Volte](https://github.com/GreemDev/Volte) (Discord.Net)
+* [GreemDev](https://github.com/GreemDev)'s Discord bot: [Volte](https://github.com/GreemDev/Volte) (DSharpPlus)
 * [TheCasino](https://github.com/TheCasino)'s Discord bot: [Espeon](https://github.com/TheCasino/Espeon) (Discord.Net)
 * [BlowaXD](https://github.com/BlowaXD)'s Nostale Server Emulator: [SaltyEmu](https://github.com/BlowaXD/SaltyEmu) 
 
@@ -35,8 +39,8 @@ There's currently no official documentation for Qmmands other than the usage exa
 ```cs
 private readonly CommandService _service = new CommandService();
 
-// Imagine this being a message callback, whether it'd be from an IRC bot,
-// a Discord bot, or any other chat based commands bot.
+// Imagine this being a message callback, whether it be from an IRC bot,
+// a Discord bot, or any other chat based service.
 private async Task MessageReceivedAsync(Message message)
 {
     if (!CommandUtilities.HasPrefix(message.Content, '!', out string output))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ artifacts:
   
 deploy:
 - provider: NuGet
-  server: https://www.myget.org/F/qmmands/api/v2
+  server: https://www.myget.org/F/quahu/api/v2
   api_key:
     secure: XW7HgRlmPz8/YHNSCAjAzBbYvgTx1dVSA+OU8AmuU6OamtFJnUr2CCAbHukPg0r7
   skip_symbols: true

--- a/src/Qmmands.sln
+++ b/src/Qmmands.sln
@@ -1,7 +1,7 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28124.53
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28621.142
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Qmmands", "Qmmands\Qmmands.csproj", "{756B30F0-22C9-4924-95F6-206B26EF5291}"
 EndProject

--- a/src/Qmmands/Attributes/Checks/CheckAttribute.cs
+++ b/src/Qmmands/Attributes/Checks/CheckAttribute.cs
@@ -37,6 +37,12 @@ namespace Qmmands
         /// <returns>
         ///     A <see cref="CheckResult"/> which determines whether this <see cref="CheckAttribute"/> succeeded or not.
         /// </returns>
-        public abstract Task<CheckResult> CheckAsync(CommandContext context, IServiceProvider provider);
+        public abstract
+#if NETCOREAPP
+            ValueTask<CheckResult>
+#else
+            Task<CheckResult>
+#endif
+            CheckAsync(CommandContext context, IServiceProvider provider);
     }
 }

--- a/src/Qmmands/Attributes/Checks/CheckAttribute.cs
+++ b/src/Qmmands/Attributes/Checks/CheckAttribute.cs
@@ -7,16 +7,16 @@ namespace Qmmands
     ///     Represents a <see cref="Qmmands.Module"/> or <see cref="Qmmands.Command"/> check that has to succeed before it can be executed.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
-    public abstract class CheckBaseAttribute : Attribute
+    public abstract class CheckAttribute : Attribute
     {
         /// <summary>
-        ///     Gets the <see cref="Qmmands.Module"/> this <see cref="CheckBaseAttribute"/> is for.
+        ///     Gets the <see cref="Qmmands.Module"/> this <see cref="CheckAttribute"/> is for.
         ///     <see langword="null"/> if this check is for a <see cref="Qmmands.Command"/>.
         /// </summary>
         public Module Module { get; internal set; }
 
         /// <summary>
-        ///     Gets the <see cref="Qmmands.Command"/> this <see cref="CheckBaseAttribute"/> is for.
+        ///     Gets the <see cref="Qmmands.Command"/> this <see cref="CheckAttribute"/> is for.
         ///     <see langword="null"/> if this check is for a <see cref="Qmmands.Module"/>.
         /// </summary>
         public Command Command { get; internal set; }
@@ -32,11 +32,11 @@ namespace Qmmands
         /// <summary>
         ///     A method which determines whether the <see cref="Module"/> or <see cref="Command"/> can execute in given circumstances.
         /// </summary>
-        /// <param name="context"> The <see cref="ICommandContext"/> used during execution. </param>
+        /// <param name="context"> The <see cref="CommandContext"/> used during execution. </param>
         /// <param name="provider"> The <see cref="IServiceProvider"/> used during execution. </param>
         /// <returns>
-        ///     A <see cref="CheckResult"/> which determines whether this <see cref="CheckBaseAttribute"/> succeeded or not.
+        ///     A <see cref="CheckResult"/> which determines whether this <see cref="CheckAttribute"/> succeeded or not.
         /// </returns>
-        public abstract Task<CheckResult> CheckAsync(ICommandContext context, IServiceProvider provider);
+        public abstract Task<CheckResult> CheckAsync(CommandContext context, IServiceProvider provider);
     }
 }

--- a/src/Qmmands/Attributes/Checks/ParameterCheckAttribute.cs
+++ b/src/Qmmands/Attributes/Checks/ParameterCheckAttribute.cs
@@ -31,6 +31,12 @@ namespace Qmmands
         /// <returns>
         ///     A <see cref="CheckResult"/> which determines whether this <see cref="ParameterCheckAttribute"/> succeeded or not.
         /// </returns>
-        public abstract Task<CheckResult> CheckAsync(object argument, CommandContext context, IServiceProvider provider);
+        public abstract
+#if NETCOREAPP
+            ValueTask<CheckResult>
+#else
+            Task<CheckResult>
+#endif
+            CheckAsync(object argument, CommandContext context, IServiceProvider provider);
     }
 }

--- a/src/Qmmands/Attributes/Checks/ParameterCheckAttribute.cs
+++ b/src/Qmmands/Attributes/Checks/ParameterCheckAttribute.cs
@@ -7,10 +7,10 @@ namespace Qmmands
     ///     Represents a <see cref="Qmmands.Parameter"/> check that has to succeed before the <see cref="Command"/> can be executed.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true)]
-    public abstract class ParameterCheckBaseAttribute : Attribute
+    public abstract class ParameterCheckAttribute : Attribute
     {
         /// <summary>
-        ///     Gets the <see cref="Qmmands.Parameter"/> this <see cref="ParameterCheckBaseAttribute"/> is for.
+        ///     Gets the <see cref="Qmmands.Parameter"/> this <see cref="ParameterCheckAttribute"/> is for.
         /// </summary>
         public Parameter Parameter { get; internal set; }
 
@@ -29,7 +29,7 @@ namespace Qmmands
         /// <param name="context"> The <see cref="CommandContext"/> used during execution. </param>
         /// <param name="provider"> The <see cref="IServiceProvider"/> used during execution. </param>
         /// <returns>
-        ///     A <see cref="CheckResult"/> which determines whether this <see cref="ParameterCheckBaseAttribute"/> succeeded or not.
+        ///     A <see cref="CheckResult"/> which determines whether this <see cref="ParameterCheckAttribute"/> succeeded or not.
         /// </returns>
         public abstract Task<CheckResult> CheckAsync(object argument, CommandContext context, IServiceProvider provider);
     }

--- a/src/Qmmands/Attributes/Checks/ParameterCheckBaseAttribute.cs
+++ b/src/Qmmands/Attributes/Checks/ParameterCheckBaseAttribute.cs
@@ -26,11 +26,11 @@ namespace Qmmands
         ///     A method which determines whether the <paramref name="argument"/> is valid for the <see cref="Parameter"/> in given circumstances.
         /// </summary>
         /// <param name="argument"> The value given to this <see cref="Parameter"/>. </param>
-        /// <param name="context"> The <see cref="ICommandContext"/> used during execution. </param>
+        /// <param name="context"> The <see cref="CommandContext"/> used during execution. </param>
         /// <param name="provider"> The <see cref="IServiceProvider"/> used during execution. </param>
         /// <returns>
         ///     A <see cref="CheckResult"/> which determines whether this <see cref="ParameterCheckBaseAttribute"/> succeeded or not.
         /// </returns>
-        public abstract Task<CheckResult> CheckAsync(object argument, ICommandContext context, IServiceProvider provider);
+        public abstract Task<CheckResult> CheckAsync(object argument, CommandContext context, IServiceProvider provider);
     }
 }

--- a/src/Qmmands/Attributes/Commands/OverrideTypeParserAttribute.cs
+++ b/src/Qmmands/Attributes/Commands/OverrideTypeParserAttribute.cs
@@ -6,7 +6,7 @@ namespace Qmmands
     ///     Overrides the type parser for the <see cref="Parameter"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
-    public sealed class OverrideTypeParserAttribute : Attribute
+    public class OverrideTypeParserAttribute : Attribute
     {
         /// <summary>
         ///     Gets the <see cref="Type"/> of the custom type parser.

--- a/src/Qmmands/Builders/CommandBuilder.cs
+++ b/src/Qmmands/Builders/CommandBuilder.cs
@@ -33,8 +33,6 @@ namespace Qmmands
         /// </summary>
         public int Priority { get; set; }
 
-        private RunMode? _runMode;
-
         /// <summary>
         ///     Gets or sets the <see cref="Qmmands.RunMode"/> of the <see cref="Command"/>.
         /// </summary>
@@ -49,11 +47,7 @@ namespace Qmmands
                 _runMode = value;
             }
         }
-
-        /// <summary>
-        ///     Gets or sets the callback of the <see cref="Command"/>.
-        /// </summary>
-        public CommandCallbackDelegate Callback { get; set; }
+        private RunMode? _runMode;
 
         /// <summary>
         ///     Gets the <see cref="Cooldown"/>s of the <see cref="Command"/>.
@@ -80,11 +74,14 @@ namespace Qmmands
         /// </summary>
         public List<ParameterBuilder> Parameters { get; }
 
+        internal CommandCallbackDelegate Callback { get; }
+
         /// <summary>
         ///     Initialises a new <see cref="CommandBuilder"/>.
         /// </summary>
-        public CommandBuilder()
+        public CommandBuilder(CommandCallbackDelegate callback)
         {
+            Callback = callback;
             Cooldowns = new List<Cooldown>();
             Aliases = new List<string>();
             Checks = new List<CheckAttribute>();
@@ -143,15 +140,6 @@ namespace Qmmands
         public CommandBuilder WithRunMode(RunMode? runMode)
         {
             RunMode = runMode;
-            return this;
-        }
-
-        /// <summary>
-        ///     Sets the <see cref="Callback"/>.
-        /// </summary>
-        public CommandBuilder WithCallback(CommandCallbackDelegate callback)
-        {
-            Callback = callback;
             return this;
         }
 
@@ -262,12 +250,12 @@ namespace Qmmands
             if (Callback is null)
                 throw new CommandBuildingException(this, "Command's callback must not be null.");
 
-            var aliases = new List<string>();
+            var aliases = new List<string>(Aliases.Count);
             for (var i = 0; i < Aliases.Count; i++)
             {
                 var alias = Aliases[i];
-                if (string.IsNullOrEmpty(alias))
-                    throw new CommandBuildingException(this, "Command's aliases must not contain null or empty entries.");
+                if (alias == null)
+                    throw new CommandBuildingException(this, "Command's aliases must not contain null entries.");
 
                 if (aliases.Contains(alias))
                     throw new CommandBuildingException(this, "Command's aliases must not contain duplicates.");

--- a/src/Qmmands/Builders/CommandBuilder.cs
+++ b/src/Qmmands/Builders/CommandBuilder.cs
@@ -74,13 +74,16 @@ namespace Qmmands
         /// </summary>
         public List<ParameterBuilder> Parameters { get; }
 
+        /// <summary>
+        ///     Gets the module of the <see cref="Command"/>.
+        /// </summary>
+        public ModuleBuilder Module { get; }
+
         internal CommandCallbackDelegate Callback { get; }
 
-        /// <summary>
-        ///     Initialises a new <see cref="CommandBuilder"/>.
-        /// </summary>
-        public CommandBuilder(CommandCallbackDelegate callback)
+        internal CommandBuilder(ModuleBuilder module, CommandCallbackDelegate callback)
         {
+            Module = module;
             Callback = callback;
             Cooldowns = new List<Cooldown>();
             Aliases = new List<string>();
@@ -203,7 +206,7 @@ namespace Qmmands
         /// <param name="builderAction"> The action to perform on the builder. </param>
         public CommandBuilder AddParameter(Action<ParameterBuilder> builderAction)
         {
-            var builder = new ParameterBuilder();
+            var builder = new ParameterBuilder(this);
             builderAction(builder);
             Parameters.Add(builder);
             return this;

--- a/src/Qmmands/Builders/CommandBuilder.cs
+++ b/src/Qmmands/Builders/CommandBuilder.cs
@@ -68,7 +68,7 @@ namespace Qmmands
         /// <summary>
         ///     Gets the checks of the <see cref="Command"/>.
         /// </summary>
-        public List<CheckBaseAttribute> Checks { get; }
+        public List<CheckAttribute> Checks { get; }
 
         /// <summary>
         ///     Gets the custom attributes of the <see cref="Command"/>.
@@ -87,7 +87,7 @@ namespace Qmmands
         {
             Cooldowns = new List<Cooldown>();
             Aliases = new List<string>();
-            Checks = new List<CheckBaseAttribute>();
+            Checks = new List<CheckAttribute>();
             Attributes = new List<Attribute>();
             Parameters = new List<ParameterBuilder>();
         }
@@ -194,7 +194,7 @@ namespace Qmmands
         /// <summary>
         ///     Adds a check to <see cref="Checks"/>.
         /// </summary>
-        public CommandBuilder AddCheck(CheckBaseAttribute check)
+        public CommandBuilder AddCheck(CheckAttribute check)
         {
             Checks.Add(check);
             return this;
@@ -203,7 +203,7 @@ namespace Qmmands
         /// <summary>
         ///     Adds checks to <see cref="Checks"/>.
         /// </summary>
-        public CommandBuilder AddChecks(params CheckBaseAttribute[] checks)
+        public CommandBuilder AddChecks(params CheckAttribute[] checks)
         {
             Checks.AddRange(checks);
             return this;

--- a/src/Qmmands/Builders/CommandBuilder.cs
+++ b/src/Qmmands/Builders/CommandBuilder.cs
@@ -26,7 +26,7 @@ namespace Qmmands
         /// <summary>
         ///     Gets or sets whether the <see cref="Command"/> should ignore extra arguments or not.
         /// </summary>
-        public bool? IgnoreExtraArguments { get; set; }
+        public bool? IgnoresExtraArguments { get; set; }
 
         /// <summary>
         ///     Gets or sets the priority of the <see cref="Command"/>.
@@ -120,11 +120,11 @@ namespace Qmmands
         }
 
         /// <summary>
-        ///     Sets the <see cref="IgnoreExtraArguments"/>.
+        ///     Sets the <see cref="IgnoresExtraArguments"/>.
         /// </summary>
-        public CommandBuilder WithIgnoreExtraArguments(bool ignoreExtraArguments)
+        public CommandBuilder WithIgnoreExtraArguments(bool? ignoreExtraArguments)
         {
-            IgnoreExtraArguments = ignoreExtraArguments;
+            IgnoresExtraArguments = ignoreExtraArguments;
             return this;
         }
 

--- a/src/Qmmands/Builders/CommandBuilder.cs
+++ b/src/Qmmands/Builders/CommandBuilder.cs
@@ -206,27 +206,12 @@ namespace Qmmands
         /// <param name="builderAction"> The action to perform on the builder. </param>
         public CommandBuilder AddParameter(Action<ParameterBuilder> builderAction)
         {
+            if (builderAction == null)
+                throw new ArgumentNullException(nameof(builderAction));
+
             var builder = new ParameterBuilder(this);
             builderAction(builder);
             Parameters.Add(builder);
-            return this;
-        }
-
-        /// <summary>
-        ///     Adds a parameter to <see cref="Parameters"/>.
-        /// </summary>
-        public CommandBuilder AddParameter(ParameterBuilder parameter)
-        {
-            Parameters.Add(parameter);
-            return this;
-        }
-
-        /// <summary>
-        ///     Adds parameters to <see cref="Parameters"/>.
-        /// </summary>
-        public CommandBuilder AddParameters(params ParameterBuilder[] parameters)
-        {
-            Parameters.AddRange(parameters);
             return this;
         }
 

--- a/src/Qmmands/Builders/CommandBuilder.cs
+++ b/src/Qmmands/Builders/CommandBuilder.cs
@@ -122,9 +122,9 @@ namespace Qmmands
         /// <summary>
         ///     Sets the <see cref="IgnoresExtraArguments"/>.
         /// </summary>
-        public CommandBuilder WithIgnoreExtraArguments(bool? ignoreExtraArguments)
+        public CommandBuilder WithIgnoresExtraArguments(bool? ignoresExtraArguments)
         {
-            IgnoresExtraArguments = ignoreExtraArguments;
+            IgnoresExtraArguments = ignoresExtraArguments;
             return this;
         }
 

--- a/src/Qmmands/Builders/ModuleBuilder.cs
+++ b/src/Qmmands/Builders/ModuleBuilder.cs
@@ -132,9 +132,9 @@ namespace Qmmands
         /// <summary>
         ///     Sets the <see cref="IgnoresExtraArguments"/>.
         /// </summary>
-        public ModuleBuilder WithIgnoreExtraArguments(bool? ignoreExtraArguments)
+        public ModuleBuilder WithIgnoresExtraArguments(bool? ignoresExtraArguments)
         {
-            IgnoresExtraArguments = ignoreExtraArguments;
+            IgnoresExtraArguments = ignoresExtraArguments;
             return this;
         }
 

--- a/src/Qmmands/Builders/ModuleBuilder.cs
+++ b/src/Qmmands/Builders/ModuleBuilder.cs
@@ -42,7 +42,7 @@ namespace Qmmands
         /// <summary>
         ///     Gets or sets whether the <see cref="Command"/>s in the <see cref="Module"/> should ignore extra arguments or not.
         /// </summary>
-        public bool? IgnoreExtraArguments { get; set; }
+        public bool? IgnoresExtraArguments { get; set; }
 
         /// <summary>
         ///     Gets the aliases of the <see cref="Module"/>.
@@ -130,11 +130,11 @@ namespace Qmmands
         }
 
         /// <summary>
-        ///     Sets the <see cref="IgnoreExtraArguments"/>.
+        ///     Sets the <see cref="IgnoresExtraArguments"/>.
         /// </summary>
         public ModuleBuilder WithIgnoreExtraArguments(bool? ignoreExtraArguments)
         {
-            IgnoreExtraArguments = ignoreExtraArguments;
+            IgnoresExtraArguments = ignoreExtraArguments;
             return this;
         }
 

--- a/src/Qmmands/Builders/ModuleBuilder.cs
+++ b/src/Qmmands/Builders/ModuleBuilder.cs
@@ -217,6 +217,9 @@ namespace Qmmands
         /// <param name="builderAction"> The action to perform on the builder. </param>
         public ModuleBuilder AddSubmodule(Action<ModuleBuilder> builderAction)
         {
+            if (builderAction == null)
+                throw new ArgumentNullException(nameof(builderAction));
+
             var builder = new ModuleBuilder(this);
             builderAction(builder);
             Submodules.Add(builder);

--- a/src/Qmmands/Builders/ModuleBuilder.cs
+++ b/src/Qmmands/Builders/ModuleBuilder.cs
@@ -53,7 +53,7 @@ namespace Qmmands
         /// <summary>
         ///     Gets the checks of the <see cref="Module"/>.
         /// </summary>
-        public List<CheckBaseAttribute> Checks { get; }
+        public List<CheckAttribute> Checks { get; }
 
         /// <summary>
         ///     Gets the attributes of the <see cref="Module"/>.
@@ -78,7 +78,7 @@ namespace Qmmands
         public ModuleBuilder()
         {
             Aliases = new List<string>();
-            Checks = new List<CheckBaseAttribute>();
+            Checks = new List<CheckAttribute>();
             Attributes = new List<Attribute>();
             Commands = new List<CommandBuilder>();
             Submodules = new List<ModuleBuilder>();
@@ -153,7 +153,7 @@ namespace Qmmands
         /// <summary>
         ///     Adds a check to <see cref="Checks"/>.
         /// </summary>
-        public ModuleBuilder AddCheck(CheckBaseAttribute check)
+        public ModuleBuilder AddCheck(CheckAttribute check)
         {
             Checks.Add(check);
             return this;
@@ -162,7 +162,7 @@ namespace Qmmands
         /// <summary>
         ///     Adds checks to <see cref="Checks"/>.
         /// </summary>
-        public ModuleBuilder AddChecks(params CheckBaseAttribute[] checks)
+        public ModuleBuilder AddChecks(params CheckAttribute[] checks)
         {
             Checks.AddRange(checks);
             return this;

--- a/src/Qmmands/Builders/ModuleBuilder.cs
+++ b/src/Qmmands/Builders/ModuleBuilder.cs
@@ -70,16 +70,19 @@ namespace Qmmands
         public List<ModuleBuilder> Submodules { get; }
 
         /// <summary>
+        ///     Gets the parent module of the <see cref="Module"/>.
+        /// </summary>
+        public ModuleBuilder Parent { get; }
+
+        /// <summary>
         ///     Gets the <see cref="System.Type"/> this <see cref="ModuleBuilder"/> was created from.
         ///     <see langword="null"/> if this module was created using, for example, <see cref="CommandService.AddModule(Type, Action{ModuleBuilder})"/>.
         /// </summary>
         public Type Type { get; }
 
-        /// <summary>
-        ///     Initialises a new <see cref="ModuleBuilder"/>.
-        /// </summary>
-        public ModuleBuilder()
+        internal ModuleBuilder(ModuleBuilder parent)
         {
+            Parent = parent;
             Aliases = new List<string>();
             Checks = new List<CheckAttribute>();
             Attributes = new List<Attribute>();
@@ -87,7 +90,7 @@ namespace Qmmands
             Submodules = new List<ModuleBuilder>();
         }
 
-        internal ModuleBuilder(Type type) : this()
+        internal ModuleBuilder(Type type, ModuleBuilder parent) : this(parent)
             => Type = type;
 
         /// <summary>
@@ -196,27 +199,15 @@ namespace Qmmands
         /// <param name="builderAction"> The action to perform on the builder. </param>
         public ModuleBuilder AddCommand(CommandCallbackDelegate callback, Action<CommandBuilder> builderAction)
         {
-            var builder = new CommandBuilder(callback);
+            if (callback == null)
+                throw new ArgumentNullException(nameof(callback));
+
+            if (builderAction == null)
+                throw new ArgumentNullException(nameof(builderAction));
+
+            var builder = new CommandBuilder(this, callback);
             builderAction(builder);
             Commands.Add(builder);
-            return this;
-        }
-
-        /// <summary>
-        ///     Adds a command to <see cref="Commands"/>.
-        /// </summary>
-        public ModuleBuilder AddCommand(CommandBuilder commandBuilder)
-        {
-            Commands.Add(commandBuilder);
-            return this;
-        }
-
-        /// <summary>
-        ///     Adds commands to <see cref="Commands"/>.
-        /// </summary>
-        public ModuleBuilder AddCommands(params CommandBuilder[] commandBuilders)
-        {
-            Commands.AddRange(commandBuilders);
             return this;
         }
 
@@ -226,27 +217,9 @@ namespace Qmmands
         /// <param name="builderAction"> The action to perform on the builder. </param>
         public ModuleBuilder AddSubmodule(Action<ModuleBuilder> builderAction)
         {
-            var builder = new ModuleBuilder();
+            var builder = new ModuleBuilder(this);
             builderAction(builder);
             Submodules.Add(builder);
-            return this;
-        }
-
-        /// <summary>
-        ///     Adds a submodule to <see cref="Submodules"/>.
-        /// </summary>
-        public ModuleBuilder AddSubmodule(ModuleBuilder moduleBuilder)
-        {
-            Submodules.Add(moduleBuilder);
-            return this;
-        }
-
-        /// <summary>
-        ///     Adds submodules to <see cref="Submodules"/>.
-        /// </summary>
-        public ModuleBuilder AddSubmodules(params ModuleBuilder[] moduleBuilders)
-        {
-            Submodules.AddRange(moduleBuilders);
             return this;
         }
 

--- a/src/Qmmands/Builders/ParameterBuilder.cs
+++ b/src/Qmmands/Builders/ParameterBuilder.cs
@@ -56,7 +56,7 @@ namespace Qmmands
         /// <summary>
         ///     Gets the checks of the <see cref="Parameter"/>.
         /// </summary>
-        public List<ParameterCheckBaseAttribute> Checks { get; }
+        public List<ParameterCheckAttribute> Checks { get; }
 
         /// <summary>
         ///     Gets the attributes of the <see cref="Parameter"/>.
@@ -68,7 +68,7 @@ namespace Qmmands
         /// </summary>
         public ParameterBuilder()
         {
-            Checks = new List<ParameterCheckBaseAttribute>();
+            Checks = new List<ParameterCheckAttribute>();
             Attributes = new List<Attribute>();
         }
 
@@ -156,7 +156,7 @@ namespace Qmmands
         /// <summary>
         ///     Adds a check to <see cref="Checks"/>.
         /// </summary>
-        public ParameterBuilder AddCheck(ParameterCheckBaseAttribute check)
+        public ParameterBuilder AddCheck(ParameterCheckAttribute check)
         {
             Checks.Add(check);
             return this;
@@ -165,7 +165,7 @@ namespace Qmmands
         /// <summary>
         ///     Adds checks to <see cref="Checks"/>.
         /// </summary>
-        public ParameterBuilder AddChecks(params ParameterCheckBaseAttribute[] checks)
+        public ParameterBuilder AddChecks(params ParameterCheckAttribute[] checks)
         {
             Checks.AddRange(checks);
             return this;

--- a/src/Qmmands/Builders/ParameterBuilder.cs
+++ b/src/Qmmands/Builders/ParameterBuilder.cs
@@ -64,10 +64,13 @@ namespace Qmmands
         public List<Attribute> Attributes { get; }
 
         /// <summary>
-        ///     Initialises a new <see cref="ParameterBuilder"/>.
+        ///     Gets the command of the <see cref="Parameter"/>.
         /// </summary>
-        public ParameterBuilder()
+        public CommandBuilder Command { get; }
+
+        internal ParameterBuilder(CommandBuilder command)
         {
+            Command = command;
             Checks = new List<ParameterCheckAttribute>();
             Attributes = new List<Attribute>();
         }

--- a/src/Qmmands/Built/Command.cs
+++ b/src/Qmmands/Built/Command.cs
@@ -40,7 +40,7 @@ namespace Qmmands
         /// <summary>
         ///     Gets whether this <see cref="Command"/> ignores extra arguments or not.
         /// </summary>
-        public bool IgnoreExtraArguments { get; }
+        public bool IgnoresExtraArguments { get; }
 
         /// <summary>
         ///     Gets the <see cref="Cooldown"/>s of this <see cref="Command"/>.
@@ -96,7 +96,7 @@ namespace Qmmands
             Remarks = builder.Remarks;
             Priority = builder.Priority;
             RunMode = builder.RunMode ?? module.RunMode;
-            IgnoreExtraArguments = builder.IgnoreExtraArguments ?? module.IgnoreExtraArguments;
+            IgnoresExtraArguments = builder.IgnoresExtraArguments ?? module.IgnoresExtraArguments;
             Callback = builder.Callback;
             Cooldowns = builder.Cooldowns.OrderBy(x => x.Amount).ToImmutableArray();
             var aliases = builder.Aliases.ToImmutableArray();

--- a/src/Qmmands/Built/Module.cs
+++ b/src/Qmmands/Built/Module.cs
@@ -34,7 +34,7 @@ namespace Qmmands
         /// <summary>
         ///     Gets whether this <see cref="Module"/>'s commands ignore extra arguments or not.
         /// </summary>
-        public bool IgnoreExtraArguments { get; }
+        public bool IgnoresExtraArguments { get; }
 
         /// <summary>
         ///     Gets the aliases of this <see cref="Module"/>.
@@ -91,7 +91,7 @@ namespace Qmmands
             Description = builder.Description;
             Remarks = builder.Remarks;
             RunMode = builder.RunMode ?? Parent?.RunMode ?? Service.DefaultRunMode;
-            IgnoreExtraArguments = builder.IgnoreExtraArguments ?? Parent?.IgnoreExtraArguments ?? Service.IgnoreExtraArguments;
+            IgnoresExtraArguments = builder.IgnoresExtraArguments ?? Parent?.IgnoresExtraArguments ?? Service.IgnoresExtraArguments;
             var aliases = builder.Aliases.ToImmutableArray();
             Aliases = aliases;
 

--- a/src/Qmmands/Built/Module.cs
+++ b/src/Qmmands/Built/Module.cs
@@ -52,7 +52,7 @@ namespace Qmmands
         /// <summary>
         ///     Gets the checks of this <see cref="Module"/>.
         /// </summary>
-        public IReadOnlyList<CheckBaseAttribute> Checks { get; }
+        public IReadOnlyList<CheckAttribute> Checks { get; }
 
         /// <summary>
         ///     Gets the attributes of this <see cref="Module"/>.
@@ -130,12 +130,12 @@ namespace Qmmands
         /// <summary>
         ///     Runs checks on parent <see cref="Module"/>s and this <see cref="Module"/>.
         /// </summary>
-        /// <param name="context"> The <see cref="ICommandContext"/> used for execution. </param>
+        /// <param name="context"> The <see cref="CommandContext"/> used for execution. </param>
         /// <param name="provider"> The <see cref="IServiceProvider"/> used for execution. </param>
         /// <returns>
         ///     A <see cref="SuccessfulResult"/> if all of the checks pass, otherwise a <see cref="ChecksFailedResult"/>.
         /// </returns>
-        public async Task<IResult> RunChecksAsync(ICommandContext context, IServiceProvider provider = null)
+        public async Task<IResult> RunChecksAsync(CommandContext context, IServiceProvider provider = null)
         {
             if (provider is null)
                 provider = DummyServiceProvider.Instance;
@@ -149,7 +149,7 @@ namespace Qmmands
 
             if (Checks.Count > 0)
             {
-                async Task<(CheckBaseAttribute Check, CheckResult Result)> RunCheckAsync(CheckBaseAttribute check)
+                async Task<(CheckAttribute Check, CheckResult Result)> RunCheckAsync(CheckAttribute check)
                 {
                     var checkResult = await check.CheckAsync(context, provider).ConfigureAwait(false);
                     return (check, checkResult);

--- a/src/Qmmands/Built/Module.cs
+++ b/src/Qmmands/Built/Module.cs
@@ -76,7 +76,7 @@ namespace Qmmands
 
         /// <summary>
         ///     Gets the <see cref="System.Type"/> this <see cref="Module"/> was built from.
-        ///     <see langword="null"/> if it was built from a <see cref="ModuleBuilder"/>.
+        ///     <see langword="null"/> if it was built using a <see cref="ModuleBuilder"/>.
         /// </summary>
         public Type Type { get; }
 

--- a/src/Qmmands/Built/Parameter.cs
+++ b/src/Qmmands/Built/Parameter.cs
@@ -107,12 +107,12 @@ namespace Qmmands
         ///     Runs parameter checks on this <see cref="Parameter"/>.
         /// </summary>
         /// <param name="argument"> The parsed argument value for this <see cref="Parameter"/>. </param>
-        /// <param name="context"> The <see cref="ICommandContext"/> used for execution. </param>
+        /// <param name="context"> The <see cref="CommandContext"/> used for execution. </param>
         /// <param name="provider"> The <see cref="IServiceProvider"/> used for execution. </param>
         /// <returns>
         ///     A <see cref="SuccessfulResult"/> if all of the checks pass, otherwise a <see cref="ChecksFailedResult"/>.
         /// </returns>
-        public async Task<IResult> RunChecksAsync(object argument, ICommandContext context, IServiceProvider provider = null)
+        public async Task<IResult> RunChecksAsync(object argument, CommandContext context, IServiceProvider provider = null)
         {
             if (provider is null)
                 provider = DummyServiceProvider.Instance;

--- a/src/Qmmands/Built/Parameter.cs
+++ b/src/Qmmands/Built/Parameter.cs
@@ -59,7 +59,7 @@ namespace Qmmands
         /// <summary>
         ///     Gets the checks of this <see cref="Parameter"/>.
         /// </summary>
-        public IReadOnlyList<ParameterCheckBaseAttribute> Checks { get; }
+        public IReadOnlyList<ParameterCheckAttribute> Checks { get; }
 
         /// <summary>
         ///     Gets the attributes of this <see cref="Parameter"/>.
@@ -119,7 +119,7 @@ namespace Qmmands
 
             if (Checks.Count > 0)
             {
-                async Task<(ParameterCheckBaseAttribute Check, CheckResult Result)> RunCheckAsync(ParameterCheckBaseAttribute check)
+                async Task<(ParameterCheckAttribute Check, CheckResult Result)> RunCheckAsync(ParameterCheckAttribute check)
                 {
                     var checkResult = await check.CheckAsync(argument, context, provider).ConfigureAwait(false);
                     return (check, checkResult);

--- a/src/Qmmands/CommandService.cs
+++ b/src/Qmmands/CommandService.cs
@@ -16,9 +16,9 @@ namespace Qmmands
     public class CommandService : ICommandService
     {
         /// <summary>
-        ///     Gets whether <see cref="FindCommands"/> and primitive <see langword="enum"/> type parsers are case sensitive or not.
+        ///     Gets whether <see cref="FindModules"/>, <see cref="FindCommands"/> and primitive <see langword="enum"/> type parsers are case sensitive or not.
         /// </summary>
-        public bool CaseSensitive { get; }
+        public bool IsCaseSensitive { get; }
 
         /// <summary>
         ///     Gets the default <see cref="RunMode"/> for commands and modules.
@@ -28,7 +28,7 @@ namespace Qmmands
         /// <summary>
         ///     Gets whether commands should ignore extra arguments by default or not.
         /// </summary>
-        public bool IgnoreExtraArguments { get; }
+        public bool IgnoresExtraArguments { get; }
 
         /// <summary>
         ///     Gets the separator.
@@ -141,9 +141,9 @@ namespace Qmmands
             if (configuration == null)
                 throw new ArgumentNullException(nameof(configuration), "The configuration must not be null.");
 
-            CaseSensitive = configuration.CaseSensitive;
+            IsCaseSensitive = configuration.CaseSensitive;
             DefaultRunMode = configuration.DefaultRunMode;
-            IgnoreExtraArguments = configuration.IgnoreExtraArguments;
+            IgnoresExtraArguments = configuration.IgnoreExtraArguments;
             Separator = configuration.Separator;
             SeparatorRequirement = configuration.SeparatorRequirement;
             ArgumentParser = configuration.ArgumentParser ?? new DefaultArgumentParser();
@@ -155,7 +155,7 @@ namespace Qmmands
                 ? configuration.NullableNouns.ToImmutableArray()
                 : CommandUtilities.DefaultNullableNouns;
 
-            StringComparison = CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+            StringComparison = IsCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
 
             _typeModules = new Dictionary<Type, Module>();
             _modules = new HashSet<Module>();

--- a/src/Qmmands/CommandService.cs
+++ b/src/Qmmands/CommandService.cs
@@ -473,35 +473,6 @@ namespace Qmmands
         }
 
         /// <summary>
-        ///     Attempts to build the specified <see cref="ModuleBuilder"/> into a <see cref="Module"/>.
-        /// </summary>
-        /// <param name="builder"> The builder to build. </param>
-        /// <returns>
-        ///     A <see cref="Module"/>.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        ///     The module builder to add must not be null.
-        /// </exception>
-        /// <exception cref="CommandMappingException">
-        ///     Cannot map commands to the root node.
-        /// </exception>
-        /// <exception cref="CommandMappingException">
-        ///     Cannot map multiple overloads with the same signature.
-        /// </exception>
-        /// <exception cref="CommandMappingException">
-        ///     Cannot map multiple overloads with the same argument types, with one of them being a remainder, if the other one ignores extra arguments.
-        /// </exception>
-        public Module AddModule(ModuleBuilder builder)
-        {
-            if (builder == null)
-                throw new ArgumentNullException(nameof(builder), "The module builder to add must not be null.");
-
-            var module = builder.Build(this, null);
-            AddModuleInternal(module);
-            return module;
-        }
-
-        /// <summary>
         ///     Attempts to instantiate, modify, and build a <see cref="ModuleBuilder"/> into a <see cref="Module"/>.
         /// </summary>
         /// <param name="action"> The action to perform on the builder. </param>
@@ -525,9 +496,11 @@ namespace Qmmands
             if (action == null)
                 throw new ArgumentNullException(nameof(action), "The action must not be null.");
 
-            var builder = new ModuleBuilder();
+            var builder = new ModuleBuilder(null);
             action(builder);
-            return AddModule(builder);
+            var module = builder.Build(this, null);
+            AddModuleInternal(module);
+            return module;
         }
 
         /// <summary>
@@ -611,7 +584,7 @@ namespace Qmmands
             if (type is null)
                 throw new ArgumentNullException(nameof(type), "The type to add must not be null.");
 
-            var builder = ReflectionUtilities.CreateModuleBuilder(this, type.GetTypeInfo());
+            var builder = ReflectionUtilities.CreateModuleBuilder(this, null, type.GetTypeInfo());
             action?.Invoke(builder);
             var module = builder.Build(this, null);
             AddModuleInternal(module);
@@ -639,7 +612,7 @@ namespace Qmmands
                 if (module.Type != null && _typeModules.ContainsKey(module.Type))
                     throw new ArgumentException($"{module.Type} has already been added as a module.", nameof(module));
 
-                _map.MapModule(module, new List<string>());
+                _map.MapModule(module);
                 _modules.Add(module);
                 AddSubmodules(module);
             }
@@ -690,7 +663,7 @@ namespace Qmmands
                 if (!_modules.Contains(module))
                     throw new ArgumentException("This module has not been added.", nameof(module));
 
-                _map.UnmapModule(module, new List<string>());
+                _map.UnmapModule(module);
                 _modules.Remove(module);
                 if (module.Type != null)
                 {

--- a/src/Qmmands/CommandService.cs
+++ b/src/Qmmands/CommandService.cs
@@ -963,9 +963,6 @@ namespace Qmmands
             if (!(argument is string value))
                 return (null, argument);
 
-            if (parameter.Type == _stringType)
-                return (null, value);
-
             IPrimitiveTypeParser primitiveParser;
             if (!(parameter.CustomTypeParserType is null))
             {
@@ -979,6 +976,9 @@ namespace Qmmands
 
                 return (null, typeParserResult.HasValue ? typeParserResult.Value : null);
             }
+
+            if (parameter.Type == _stringType)
+                return (null, value);
 
             var parser = GetAnyTypeParser(parameter.Type, (primitiveParser = GetPrimitiveTypeParser(parameter.Type)) != null);
             if (!(parser is null))

--- a/src/Qmmands/CommandService.cs
+++ b/src/Qmmands/CommandService.cs
@@ -146,7 +146,7 @@ namespace Qmmands
             IgnoresExtraArguments = configuration.IgnoreExtraArguments;
             Separator = configuration.Separator;
             SeparatorRequirement = configuration.SeparatorRequirement;
-            ArgumentParser = configuration.ArgumentParser ?? new DefaultArgumentParser();
+            ArgumentParser = configuration.ArgumentParser ?? DefaultArgumentParser.Instance;
             CooldownBucketKeyGenerator = configuration.CooldownBucketKeyGenerator;
             QuotationMarkMap = configuration.QuoteMap != null
                 ? new ReadOnlyDictionary<char, char>(configuration.QuoteMap.ToDictionary(kvp => kvp.Key, kvp => kvp.Value))
@@ -733,7 +733,7 @@ namespace Qmmands
                 ArgumentParserResult parseResult;
                 try
                 {
-                    parseResult = ArgumentParser.ParseRawArguments(match.Command, match.RawArguments);
+                    parseResult = ArgumentParser.Parse(context);
                     if (!parseResult.IsSuccessful)
                     {
                         failedOverloads.Add(match.Command, new ArgumentParseFailedResult(match.Command, parseResult));
@@ -824,7 +824,7 @@ namespace Qmmands
             ArgumentParserResult parseResult;
             try
             {
-                parseResult = ArgumentParser.ParseRawArguments(command, rawArguments);
+                parseResult = ArgumentParser.Parse(context);
                 if (!parseResult.IsSuccessful)
                     return new ArgumentParseFailedResult(command, parseResult);
             }

--- a/src/Qmmands/CommandService.cs
+++ b/src/Qmmands/CommandService.cs
@@ -141,9 +141,9 @@ namespace Qmmands
             if (configuration == null)
                 throw new ArgumentNullException(nameof(configuration), "The configuration must not be null.");
 
-            IsCaseSensitive = configuration.CaseSensitive;
+            IsCaseSensitive = configuration.IsCaseSensitive;
             DefaultRunMode = configuration.DefaultRunMode;
-            IgnoresExtraArguments = configuration.IgnoreExtraArguments;
+            IgnoresExtraArguments = configuration.IgnoresExtraArguments;
             Separator = configuration.Separator;
             SeparatorRequirement = configuration.SeparatorRequirement;
             ArgumentParser = configuration.ArgumentParser ?? DefaultArgumentParser.Instance;

--- a/src/Qmmands/CommandServiceConfiguration.cs
+++ b/src/Qmmands/CommandServiceConfiguration.cs
@@ -12,7 +12,7 @@ namespace Qmmands
         ///     Gets or sets the <see cref="bool"/> which determines whether the commands should
         ///     be case sensitive or not. Defaults to <see langword="false"/>.
         /// </summary>
-        public bool CaseSensitive { get; set; }
+        public bool IsCaseSensitive { get; set; }
 
         /// <summary>
         ///     Gets or sets the <see cref="RunMode"/> which determines whether the commands should
@@ -35,7 +35,7 @@ namespace Qmmands
         ///     Gets or sets the <see cref="bool"/> which determines whether the extra arguments
         ///     provided should be ignored. Defaults to <see langword="false"/>.
         /// </summary>
-        public bool IgnoreExtraArguments { get; set; }
+        public bool IgnoresExtraArguments { get; set; }
 
         /// <summary>
         ///     Gets or sets the <see cref="string"/> separator to use between groups and commands.

--- a/src/Qmmands/CommandServiceConfiguration.cs
+++ b/src/Qmmands/CommandServiceConfiguration.cs
@@ -64,8 +64,8 @@ namespace Qmmands
         private SeparatorRequirement _separatorRequirement = SeparatorRequirement.Separator;
 
         /// <summary>
-        ///     Gets or sets the raw argument parser.
-        ///     If <see langword="null"/>, will default to <see cref="DefaultArgumentParser"/>.
+        ///     Gets or sets the argument parser.
+        ///     If <see langword="null"/>, will default to <see cref="Qmmands.DefaultArgumentParser"/>.
         /// </summary>
         public IArgumentParser ArgumentParser { get; set; }
 

--- a/src/Qmmands/CommandUtilities.cs
+++ b/src/Qmmands/CommandUtilities.cs
@@ -372,18 +372,18 @@ namespace Qmmands
         /// </summary>
         /// <param name="module"> The <see cref="Module"/> to get the checks for. </param>
         /// <returns>
-        ///     An enumerator of all <see cref="CheckBaseAttribute"/>s.
+        ///     An enumerator of all <see cref="CheckAttribute"/>s.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///     The module must not be null.
         /// </exception>
-        public static IEnumerable<CheckBaseAttribute> GetAllChecks(Module module)
+        public static IEnumerable<CheckAttribute> GetAllChecks(Module module)
         {
             if (module == null)
                 throw new ArgumentNullException(nameof(module), "The module must not be null.");
 
             return GetAllChecksIterator();
-            IEnumerable<CheckBaseAttribute> GetAllChecksIterator()
+            IEnumerable<CheckAttribute> GetAllChecksIterator()
             {
                 if (module.Parent != null)
                 {
@@ -402,18 +402,18 @@ namespace Qmmands
         /// </summary>
         /// <param name="command"> The <see cref="Command"/> to get the checks for. </param>
         /// <returns>
-        ///     An enumerator of all <see cref="CheckBaseAttribute"/>s.
+        ///     An enumerator of all <see cref="CheckAttribute"/>s.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///     The command must not be null.
         /// </exception>
-        public static IEnumerable<CheckBaseAttribute> GetAllChecks(Command command)
+        public static IEnumerable<CheckAttribute> GetAllChecks(Command command)
         {
             if (command == null)
                 throw new ArgumentNullException(nameof(command), "The command must not be null.");
 
             return GetAllChecksIterator();
-            IEnumerable<CheckBaseAttribute> GetAllChecksIterator()
+            IEnumerable<CheckAttribute> GetAllChecksIterator()
             {
                 foreach (var check in GetAllChecks(command.Module))
                     yield return check;

--- a/src/Qmmands/CommandUtilities.cs
+++ b/src/Qmmands/CommandUtilities.cs
@@ -26,7 +26,7 @@ namespace Qmmands
         public static readonly IReadOnlyDictionary<Type, string> FriendlyPrimitiveTypeNames;
 
         /// <summary>
-        ///     Checks if the provided <see cref="string"/> starts with the specified <see cref="char"/> prefix.
+        ///     Checks if the provided <see cref="string"/> starts with the provided <see cref="char"/> prefix.
         ///     If it does, returns <see langword="true"/> and the trimmed <paramref name="output"/>.
         /// </summary>
         /// <param name="input"> The input <see cref="string"/> to check. </param>
@@ -39,10 +39,16 @@ namespace Qmmands
         ///     The input must not be null.
         /// </exception>
         public static bool HasPrefix(string input, char prefix, out string output)
-            => HasPrefix(input, prefix, false, out output);
+            => HasPrefix(
+#if NETCOREAPP
+                input != null ? input.AsSpan() : throw new ArgumentNullException(nameof(input), "The input must not be null."),
+#else
+                input,
+#endif
+                prefix, false, out output);
 
         /// <summary>
-        ///     Checks if the provided <see cref="string"/> starts with the specified <see cref="char"/> prefix.
+        ///     Checks if the provided <see cref="string"/> starts with the provided <see cref="char"/> prefix.
         ///     If it does, returns <see langword="true"/> and the trimmed <paramref name="output"/>.
         /// </summary>
         /// <param name="input"> The input <see cref="string"/> to check. </param>
@@ -60,6 +66,9 @@ namespace Qmmands
             if (input == null)
                 throw new ArgumentNullException(nameof(input), "The input must not be null.");
 
+#if NETCOREAPP
+            return HasPrefix(input.AsSpan(), prefix, ignoreCase, out output);
+#else
             if (input.Length == 0 || input[0] != (ignoreCase ? char.ToLowerInvariant(prefix) : prefix))
             {
                 output = null;
@@ -68,10 +77,11 @@ namespace Qmmands
 
             output = input.Substring(1).TrimStart();
             return true;
+#endif
         }
 
         /// <summary>
-        ///     Checks if the provided <see cref="string"/> starts with any of the specified <see cref="char"/> prefixes.
+        ///     Checks if the provided <see cref="string"/> starts with any of the provided <see cref="char"/> prefixes.
         ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
         /// </summary>
         /// <param name="input"> The input <see cref="string"/> to check. </param>
@@ -88,10 +98,16 @@ namespace Qmmands
         ///     The prefixes must not be null.
         /// </exception>
         public static bool HasAnyPrefix(string input, IReadOnlyList<char> prefixes, out char prefix, out string output)
-            => HasAnyPrefix(input, prefixes, false, out prefix, out output);
+            => HasAnyPrefix(
+#if NETCOREAPP
+                input != null ? input.AsSpan() : throw new ArgumentNullException(nameof(input), "The input must not be null."),
+#else
+                input,
+#endif
+                prefixes, false, out prefix, out output);
 
         /// <summary>
-        ///     Checks if the provided <see cref="string"/> starts with any of the specified <see cref="char"/> prefixes.
+        ///     Checks if the provided <see cref="string"/> starts with any of the provided <see cref="char"/> prefixes.
         ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
         /// </summary>
         /// <param name="input"> The input <see cref="string"/> to check. </param>
@@ -113,6 +129,10 @@ namespace Qmmands
             if (input == null)
                 throw new ArgumentNullException(nameof(input), "The input must not be null.");
 
+#if NETCOREAPP
+            return HasAnyPrefix(input.AsSpan(), prefixes, ignoreCase, out prefix, out output);
+#else
+
             if (prefixes is null)
                 throw new ArgumentNullException(nameof(prefixes), "The prefixes must not be null.");
 
@@ -129,10 +149,11 @@ namespace Qmmands
             prefix = default;
             output = null;
             return false;
+#endif
         }
 
         /// <summary>
-        ///     Checks if the provided <see cref="string"/> starts with any of the specified <see cref="char"/> prefixes.
+        ///     Checks if the provided <see cref="string"/> starts with any of the provided <see cref="char"/> prefixes.
         ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
         /// </summary>
         /// <param name="input"> The input <see cref="string"/> to check. </param>
@@ -149,10 +170,16 @@ namespace Qmmands
         ///     The prefixes must not be null.
         /// </exception>
         public static bool HasAnyPrefix(string input, IEnumerable<char> prefixes, out char prefix, out string output)
-            => HasAnyPrefix(input, prefixes, false, out prefix, out output);
+            => HasAnyPrefix(
+#if NETCOREAPP
+                input != null ? input.AsSpan() : throw new ArgumentNullException(nameof(input), "The input must not be null."),
+#else
+                input,
+#endif
+                prefixes, false, out prefix, out output);
 
         /// <summary>
-        ///     Checks if the provided <see cref="string"/> starts with any of the specified <see cref="char"/> prefixes.
+        ///     Checks if the provided <see cref="string"/> starts with any of the provided <see cref="char"/> prefixes.
         ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
         /// </summary>
         /// <param name="input"> The input <see cref="string"/> to check. </param>
@@ -173,7 +200,9 @@ namespace Qmmands
         {
             if (input == null)
                 throw new ArgumentNullException(nameof(input), "The input must not be null.");
-
+#if NETCOREAPP
+            return HasAnyPrefix(input.AsSpan(), prefixes, ignoreCase, out prefix, out output);
+#else
             if (prefixes is null)
                 throw new ArgumentNullException(nameof(prefixes), "The prefixes must not be null.");
 
@@ -189,10 +218,11 @@ namespace Qmmands
             prefix = default;
             output = null;
             return false;
+#endif
         }
 
         /// <summary>
-        ///     Checks if the provided <see cref="string"/> starts with the specified <see cref="string"/> prefix.
+        ///     Checks if the provided <see cref="string"/> starts with the provided <see cref="string"/> prefix.
         ///     If it does, returns <see langword="true"/> and the trimmed <paramref name="output"/>.
         /// </summary>
         /// <param name="input"> The input <see cref="string"/> to check. </param>
@@ -208,10 +238,16 @@ namespace Qmmands
         ///     The prefix must not be null.
         /// </exception>
         public static bool HasPrefix(string input, string prefix, out string output)
-            => HasPrefix(input, prefix, StringComparison.Ordinal, out output);
+            => HasPrefix(
+#if NETCOREAPP
+                input != null ? input.AsSpan() : throw new ArgumentNullException(nameof(input), "The input must not be null."),
+#else
+                input,
+#endif
+                prefix, StringComparison.Ordinal, out output);
 
         /// <summary>
-        ///     Checks if the provided <see cref="string"/> starts with the specified <see cref="string"/> prefix.
+        ///     Checks if the provided <see cref="string"/> starts with the provided <see cref="string"/> prefix.
         ///     If it does, returns <see langword="true"/> and the trimmed <paramref name="output"/>.
         /// </summary>
         /// <param name="input"> The input <see cref="string"/> to check. </param>
@@ -231,7 +267,9 @@ namespace Qmmands
         {
             if (input == null)
                 throw new ArgumentNullException(nameof(input), "The input must not be null.");
-
+#if NETCOREAPP
+            return HasPrefix(input.AsSpan(), prefix, stringComparison, out output);
+#else
             if (prefix == null)
                 throw new ArgumentNullException(nameof(prefix), "The prefix must not be null.");
 
@@ -243,10 +281,11 @@ namespace Qmmands
 
             output = input.Substring(prefix.Length).TrimStart();
             return true;
+#endif
         }
 
         /// <summary>
-        ///     Checks if the provided <see cref="string"/> starts with any of the specified <see cref="string"/> prefixes.
+        ///     Checks if the provided <see cref="string"/> starts with any of the provided <see cref="string"/> prefixes.
         ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
         /// </summary>
         /// <param name="input"> The input <see cref="string"/> to check. </param>
@@ -263,10 +302,16 @@ namespace Qmmands
         ///     The prefixes must not be null.
         /// </exception>
         public static bool HasAnyPrefix(string input, IReadOnlyList<string> prefixes, out string prefix, out string output)
-            => HasAnyPrefix(input, prefixes, StringComparison.Ordinal, out prefix, out output);
+            => HasAnyPrefix(
+#if NETCOREAPP
+                input != null ? input.AsSpan() : throw new ArgumentNullException(nameof(input), "The input must not be null."),
+#else
+                input,
+#endif
+                prefixes, StringComparison.Ordinal, out prefix, out output);
 
         /// <summary>
-        ///     Checks if the provided <see cref="string"/> starts with any of the specified <see cref="string"/> prefixes.
+        ///     Checks if the provided <see cref="string"/> starts with any of the provided <see cref="string"/> prefixes.
         ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
         /// </summary>
         /// <param name="input"> The input <see cref="string"/> to check. </param>
@@ -287,7 +332,9 @@ namespace Qmmands
         {
             if (input == null)
                 throw new ArgumentNullException(nameof(input), "The input must not be null.");
-
+#if NETCOREAPP
+            return HasAnyPrefix(input.AsSpan(), prefixes, stringComparison, out prefix, out output);
+#else
             if (prefixes is null)
                 throw new ArgumentNullException(nameof(prefixes), "The prefixes must not be null.");
 
@@ -304,10 +351,11 @@ namespace Qmmands
             prefix = null;
             output = null;
             return false;
+#endif
         }
 
         /// <summary>
-        ///     Checks if the provided <see cref="string"/> starts with any of the specified <see cref="string"/> prefixes.
+        ///     Checks if the provided <see cref="string"/> starts with any of the provided <see cref="string"/> prefixes.
         ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
         /// </summary>
         /// <param name="input"> The input <see cref="string"/> to check. </param>
@@ -324,10 +372,16 @@ namespace Qmmands
         ///     The prefixes must not be null.
         /// </exception>
         public static bool HasAnyPrefix(string input, IEnumerable<string> prefixes, out string prefix, out string output)
-            => HasAnyPrefix(input, prefixes, StringComparison.Ordinal, out prefix, out output);
+            => HasAnyPrefix(
+#if NETCOREAPP
+                input != null ? input.AsSpan() : throw new ArgumentNullException(nameof(input), "The input must not be null."),
+#else
+                input,
+#endif
+                prefixes, StringComparison.Ordinal, out prefix, out output);
 
         /// <summary>
-        ///     Checks if the provided <see cref="string"/> starts with any of the specified <see cref="string"/> prefixes.
+        ///     Checks if the provided <see cref="string"/> starts with any of the provided <see cref="string"/> prefixes.
         ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
         /// </summary>
         /// <param name="input"> The input <see cref="string"/> to check. </param>
@@ -348,7 +402,304 @@ namespace Qmmands
         {
             if (input == null)
                 throw new ArgumentNullException(nameof(input), "The input must not be null.");
+#if NETCOREAPP
+            return HasAnyPrefix(input.AsSpan(), prefixes, stringComparison, out prefix, out output);
+#else
+            if (prefixes is null)
+                throw new ArgumentNullException(nameof(prefixes), "The prefixes must not be null.");
 
+            foreach (var currentPrefix in prefixes)
+            {
+                if (!HasPrefix(input, currentPrefix, stringComparison, out output))
+                    continue;
+
+                prefix = currentPrefix;
+                return true;
+            }
+
+            prefix = null;
+            output = null;
+            return false;
+#endif
+        }
+
+#if NETCOREAPP
+        /// <summary>
+        ///     Checks if the provided <see cref="ReadOnlySpan{T}"/> starts with the provided <see cref="char"/> prefix.
+        ///     If it does, returns <see langword="true"/> and the trimmed <paramref name="output"/>.
+        /// </summary>
+        /// <param name="input"> The input <see cref="ReadOnlySpan{T}"/> to check. </param>
+        /// <param name="prefix"> The <see cref="char"/> prefix to check for. </param>
+        /// <param name="output"> The trimmed output. <see langword="null"/> if the prefix is not found. </param>
+        /// <returns>
+        ///     A <see cref="bool"/> which determines whether the prefix was found or not.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The input must not be null.
+        /// </exception>
+        public static bool HasPrefix(in ReadOnlySpan<char> input, char prefix, out string output)
+            => HasPrefix(input, prefix, false, out output);
+
+        /// <summary>
+        ///     Checks if the provided <see cref="ReadOnlySpan{T}"/> starts with the provided <see cref="char"/> prefix.
+        ///     If it does, returns <see langword="true"/> and the trimmed <paramref name="output"/>.
+        /// </summary>
+        /// <param name="input"> The input <see cref="ReadOnlySpan{T}"/> to check. </param>
+        /// <param name="prefix"> The <see cref="char"/> prefix to check for. </param>
+        /// <param name="ignoreCase"> Whether to ignore casing or not. </param>
+        /// <param name="output"> The trimmed output. <see langword="null"/> if the prefix is not found. </param>
+        /// <returns>
+        ///     A <see cref="bool"/> which determines whether the prefix was found or not.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The input must not be null.
+        /// </exception>
+        public static bool HasPrefix(in ReadOnlySpan<char> input, char prefix, bool ignoreCase, out string output)
+        {
+            if (input.Length == 0 || input[0] != (ignoreCase ? char.ToLowerInvariant(prefix) : prefix))
+            {
+                output = null;
+                return false;
+            }
+
+            output = new string(input.Slice(1).TrimStart());
+            return true;
+        }
+
+        /// <summary>
+        ///     Checks if the provided <see cref="ReadOnlySpan{T}"/> starts with any of the provided <see cref="char"/> prefixes.
+        ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
+        /// </summary>
+        /// <param name="input"> The input <see cref="ReadOnlySpan{T}"/> to check. </param>
+        /// <param name="prefixes"> The <see cref="char"/> prefixes to check for. </param>
+        /// <param name="prefix"> The found prefix. Default <see cref="char"/> if the prefix was not found. </param>
+        /// <param name="output"> The trimmed output. <see langword="null"/> if the prefix is not found. </param>
+        /// <returns>
+        ///     A <see cref="bool"/> which determines whether the prefix was found or not.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The prefixes must not be null.
+        /// </exception>
+        public static bool HasAnyPrefix(in ReadOnlySpan<char> input, IReadOnlyList<char> prefixes, out char prefix, out string output)
+            => HasAnyPrefix(input, prefixes, false, out prefix, out output);
+
+        /// <summary>
+        ///     Checks if the provided <see cref="ReadOnlySpan{T}"/> starts with any of the provided <see cref="char"/> prefixes.
+        ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
+        /// </summary>
+        /// <param name="input"> The input <see cref="ReadOnlySpan{T}"/> to check. </param>
+        /// <param name="prefixes"> The <see cref="char"/> prefixes to check for. </param>
+        /// <param name="ignoreCase"> Whether to ignore casing or not. </param>
+        /// <param name="prefix"> The found prefix. Default <see cref="char"/> if the prefix was not found. </param>
+        /// <param name="output"> The trimmed output. <see langword="null"/> if the prefix is not found. </param>
+        /// <returns>
+        ///     A <see cref="bool"/> which determines whether the prefix was found or not.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The prefixes must not be null.
+        /// </exception>
+        public static bool HasAnyPrefix(in ReadOnlySpan<char> input, IReadOnlyList<char> prefixes, bool ignoreCase, out char prefix, out string output)
+        {
+            if (prefixes is null)
+                throw new ArgumentNullException(nameof(prefixes), "The prefixes must not be null.");
+
+            for (var i = 0; i < prefixes.Count; i++)
+            {
+                var currentPrefix = prefixes[i];
+                if (!HasPrefix(input, currentPrefix, ignoreCase, out output))
+                    continue;
+
+                prefix = currentPrefix;
+                return true;
+            }
+
+            prefix = default;
+            output = null;
+            return false;
+        }
+
+        /// <summary>
+        ///     Checks if the provided <see cref="ReadOnlySpan{T}"/> starts with any of the provided <see cref="char"/> prefixes.
+        ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
+        /// </summary>
+        /// <param name="input"> The input <see cref="ReadOnlySpan{T}"/> to check. </param>
+        /// <param name="prefixes"> The <see cref="char"/> prefixes to check for. </param>
+        /// <param name="prefix"> The found prefix. Default <see cref="char"/> if the prefix was not found. </param>
+        /// <param name="output"> The trimmed output. <see langword="null"/> if the prefix is not found. </param>
+        /// <returns>
+        ///     A <see cref="bool"/> which determines whether the prefix was found or not.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The prefixes must not be null.
+        /// </exception>
+        public static bool HasAnyPrefix(in ReadOnlySpan<char> input, IEnumerable<char> prefixes, out char prefix, out string output)
+            => HasAnyPrefix(input, prefixes, false, out prefix, out output);
+
+        /// <summary>
+        ///     Checks if the provided <see cref="ReadOnlySpan{T}"/> starts with any of the provided <see cref="char"/> prefixes.
+        ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
+        /// </summary>
+        /// <param name="input"> The input <see cref="ReadOnlySpan{T}"/> to check. </param>
+        /// <param name="prefixes"> The <see cref="char"/> prefixes to check for. </param>
+        /// <param name="ignoreCase"> Whether to ignore casing or not. </param>
+        /// <param name="prefix"> The found prefix. Default <see cref="char"/> if the prefix was not found. </param>
+        /// <param name="output"> The trimmed output. <see langword="null"/> if the prefix is not found. </param>
+        /// <returns>
+        ///     A <see cref="bool"/> which determines whether the prefix was found or not.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The prefixes must not be null.
+        /// </exception>
+        public static bool HasAnyPrefix(in ReadOnlySpan<char> input, IEnumerable<char> prefixes, bool ignoreCase, out char prefix, out string output)
+        {
+            if (prefixes is null)
+                throw new ArgumentNullException(nameof(prefixes), "The prefixes must not be null.");
+
+            foreach (var currentPrefix in prefixes)
+            {
+                if (!HasPrefix(input, currentPrefix, ignoreCase, out output))
+                    continue;
+
+                prefix = currentPrefix;
+                return true;
+            }
+
+            prefix = default;
+            output = null;
+            return false;
+        }
+
+        /// <summary>
+        ///     Checks if the provided <see cref="ReadOnlySpan{T}"/> starts with the provided <see cref="string"/> prefix.
+        ///     If it does, returns <see langword="true"/> and the trimmed <paramref name="output"/>.
+        /// </summary>
+        /// <param name="input"> The input <see cref="ReadOnlySpan{T}"/> to check. </param>
+        /// <param name="prefix"> The <see cref="string"/> prefix to check for. </param>
+        /// <param name="output"> The trimmed output. <see langword="null"/> if the prefix is not found. </param>
+        /// <returns>
+        ///     A <see cref="bool"/> which determines whether the prefix was found or not.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The prefix must not be null.
+        /// </exception>
+        public static bool HasPrefix(in ReadOnlySpan<char> input, string prefix, out string output)
+            => HasPrefix(input, prefix, StringComparison.Ordinal, out output);
+
+        /// <summary>
+        ///     Checks if the provided <see cref="ReadOnlySpan{T}"/> starts with the provided <see cref="string"/> prefix.
+        ///     If it does, returns <see langword="true"/> and the trimmed <paramref name="output"/>.
+        /// </summary>
+        /// <param name="input"> The input <see cref="ReadOnlySpan{T}"/> to check. </param>
+        /// <param name="prefix"> The <see cref="string"/> prefix to check for. </param>
+        /// <param name="stringComparison"> The <see cref="StringComparison"/> to use when checking for the prefix. </param>
+        /// <param name="output"> The trimmed output. <see langword="null"/> if the prefix is not found. </param>
+        /// <returns>
+        ///     A <see cref="bool"/> which determines whether the prefix was found or not.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The prefix must not be null.
+        /// </exception>
+        public static bool HasPrefix(in ReadOnlySpan<char> input, string prefix, StringComparison stringComparison, out string output)
+        {
+            if (prefix == null)
+                throw new ArgumentNullException(nameof(prefix), "The prefix must not be null.");
+
+            if (!input.StartsWith(prefix, stringComparison))
+            {
+                output = null;
+                return false;
+            }
+
+            output = new string(input.Slice(prefix.Length).TrimStart());
+            return true;
+        }
+
+        /// <summary>
+        ///     Checks if the provided <see cref="ReadOnlySpan{T}"/> starts with any of the provided <see cref="string"/> prefixes.
+        ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
+        /// </summary>
+        /// <param name="input"> The input <see cref="ReadOnlySpan{T}"/> to check. </param>
+        /// <param name="prefixes"> The <see cref="string"/> prefixes to check for. </param>
+        /// <param name="prefix"> The found prefix. <see langword="null"/> if the prefix is not found. </param>
+        /// <param name="output"> The trimmed output. <see langword="null"/> if the prefix is not found. </param>
+        /// <returns>
+        ///     A <see cref="bool"/> which determines whether the prefix was found or not.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The prefixes must not be null.
+        /// </exception>
+        public static bool HasAnyPrefix(in ReadOnlySpan<char> input, IReadOnlyList<string> prefixes, out string prefix, out string output)
+            => HasAnyPrefix(input, prefixes, StringComparison.Ordinal, out prefix, out output);
+
+        /// <summary>
+        ///     Checks if the provided <see cref="ReadOnlySpan{T}"/> starts with any of the provided <see cref="string"/> prefixes.
+        ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
+        /// </summary>
+        /// <param name="input"> The input <see cref="ReadOnlySpan{T}"/> to check. </param>
+        /// <param name="prefixes"> The <see cref="string"/> prefixes to check for. </param>
+        /// <param name="stringComparison"> The <see cref="StringComparison"/> to use when checking for the prefix. </param>
+        /// <param name="prefix"> The found prefix. <see langword="null"/> if the prefix is not found. </param>
+        /// <param name="output"> The trimmed output. <see langword="null"/> if the prefix is not found. </param>
+        /// <returns>
+        ///     A <see cref="bool"/> which determines whether the prefix was found or not.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The prefixes must not be null.
+        /// </exception>
+        public static bool HasAnyPrefix(in ReadOnlySpan<char> input, IReadOnlyList<string> prefixes, StringComparison stringComparison, out string prefix, out string output)
+        {
+            if (prefixes is null)
+                throw new ArgumentNullException(nameof(prefixes), "The prefixes must not be null.");
+
+            for (var i = 0; i < prefixes.Count; i++)
+            {
+                var currentPrefix = prefixes[i];
+                if (!HasPrefix(input, currentPrefix, stringComparison, out output))
+                    continue;
+
+                prefix = currentPrefix;
+                return true;
+            }
+
+            prefix = null;
+            output = null;
+            return false;
+        }
+
+        /// <summary>
+        ///     Checks if the provided <see cref="ReadOnlySpan{T}"/> starts with any of the provided <see cref="string"/> prefixes.
+        ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
+        /// </summary>
+        /// <param name="input"> The input <see cref="ReadOnlySpan{T}"/> to check. </param>
+        /// <param name="prefixes"> The <see cref="string"/> prefixes to check for. </param>
+        /// <param name="prefix"> The found prefix. <see langword="null"/> if the prefix is not found. </param>
+        /// <param name="output"> The trimmed output. <see langword="null"/> if the prefix is not found. </param>
+        /// <returns>
+        ///     A <see cref="bool"/> which determines whether the prefix was found or not.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The prefixes must not be null.
+        /// </exception>
+        public static bool HasAnyPrefix(in ReadOnlySpan<char> input, IEnumerable<string> prefixes, out string prefix, out string output)
+            => HasAnyPrefix(input, prefixes, StringComparison.Ordinal, out prefix, out output);
+
+        /// <summary>
+        ///     Checks if the provided <see cref="ReadOnlySpan{T}"/> starts with any of the provided <see cref="string"/> prefixes.
+        ///     If it does, returns <see langword="true"/>, the found <paramref name="prefix"/>, and the trimmed <paramref name="output"/>.
+        /// </summary>
+        /// <param name="input"> The input <see cref="ReadOnlySpan{T}"/> to check. </param>
+        /// <param name="prefixes"> The <see cref="string"/> prefixes to check for. </param>
+        /// <param name="stringComparison"> The <see cref="StringComparison"/> to use when checking for the prefix. </param>
+        /// <param name="prefix"> The found prefix. <see langword="null"/> if the prefix is not found. </param>
+        /// <param name="output"> The trimmed output. <see langword="null"/> if the prefix is not found. </param>
+        /// <returns>
+        ///     A <see cref="bool"/> which determines whether the prefix was found or not.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The prefixes must not be null.
+        /// </exception>
+        public static bool HasAnyPrefix(in ReadOnlySpan<char> input, IEnumerable<string> prefixes, StringComparison stringComparison, out string prefix, out string output)
+        {
             if (prefixes is null)
                 throw new ArgumentNullException(nameof(prefixes), "The prefixes must not be null.");
 
@@ -365,9 +716,10 @@ namespace Qmmands
             output = null;
             return false;
         }
+#endif
 
         /// <summary>
-        ///     Recursively gets all of the checks the specified <see cref="Module"/>
+        ///     Recursively gets all of the checks the provided <see cref="Module"/>
         ///     will require to pass before one of its <see cref="Command"/>s can be executed.
         /// </summary>
         /// <param name="module"> The <see cref="Module"/> to get the checks for. </param>
@@ -397,7 +749,7 @@ namespace Qmmands
         }
 
         /// <summary>
-        ///     Recursively gets all of the checks the specified <see cref="Command"/>
+        ///     Recursively gets all of the checks the provided <see cref="Command"/>
         ///     will require to pass before one of it can be executed.
         /// </summary>
         /// <param name="command"> The <see cref="Command"/> to get the checks for. </param>
@@ -424,7 +776,7 @@ namespace Qmmands
         }
 
         /// <summary>
-        ///     Recursively gets all of the <see cref="Command"/>s in the specified <see cref="Module"/> and its submodules.
+        ///     Recursively gets all of the <see cref="Command"/>s in the provided <see cref="Module"/> and its submodules.
         /// </summary>
         /// <returns>
         ///     An enumerator of all <see cref="Command"/>s.
@@ -456,7 +808,7 @@ namespace Qmmands
         }
 
         /// <summary>
-        ///     Recursively gets all of the <see cref="CommandBuilder"/>s in the specified <see cref="ModuleBuilder"/> and its submodules.
+        ///     Recursively gets all of the <see cref="CommandBuilder"/>s in the provided <see cref="ModuleBuilder"/> and its submodules.
         /// </summary>
         /// <returns>
         ///     An enumerator of all <see cref="CommandBuilder"/>s.
@@ -488,7 +840,7 @@ namespace Qmmands
         }
 
         /// <summary>
-        ///     Recursively gets all of the submodules in the specified <see cref="Module"/> and its submodules.
+        ///     Recursively gets all of the submodules in the provided <see cref="Module"/> and its submodules.
         /// </summary>
         /// <returns>
         ///     An enumerator of all <see cref="Module"/>s.
@@ -520,7 +872,7 @@ namespace Qmmands
         }
 
         /// <summary>
-        ///     Recursively gets all of the submodules in the specified <see cref="ModuleBuilder"/> and its submodules.
+        ///     Recursively gets all of the submodules in the provided <see cref="ModuleBuilder"/> and its submodules.
         /// </summary>
         /// <returns>
         ///     An enumerator of all <see cref="ModuleBuilder"/>s.

--- a/src/Qmmands/Context/CommandContext.cs
+++ b/src/Qmmands/Context/CommandContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
 namespace Qmmands
@@ -40,7 +41,7 @@ namespace Qmmands
             {
                 var arguments = _arguments;
                 return arguments == null
-                    ? (_arguments = new ReadOnlyCollection<object>(InternalArguments))
+                    ? (_arguments = new ReadOnlyCollection<object>(InternalArguments ?? Array.Empty<object>()))
                     : arguments;
             }
         }

--- a/src/Qmmands/Context/CommandContext.cs
+++ b/src/Qmmands/Context/CommandContext.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Qmmands
+{
+    /// <summary>
+    ///     The interface for custom command contexts.
+    /// </summary>
+    public abstract class CommandContext
+    {
+        /// <summary>
+        ///     Gets the currently executed <see cref="Qmmands.Command"/>.
+        /// </summary>
+        public Command Command { get; internal set; }
+
+        /// <summary>
+        ///     Gets the alias used.
+        ///     <see langword="null"/> if the <see cref="Qmmands.Command"/> was invoked without searching.
+        /// </summary>
+        public string Alias { get; internal set; }
+
+        /// <summary>
+        ///     Gets the alias path used.
+        ///     <see langword="null"/> if the <see cref="Qmmands.Command"/> was invoked without searching.
+        /// </summary>
+        public IReadOnlyList<string> Path { get; internal set; }
+
+        /// <summary>
+        ///     Gets the raw arguments.
+        ///     <see langword="null"/> if the <see cref="Qmmands.Command"/> was invoked with already parsed arguments.
+        /// </summary>
+        public string RawArguments { get; internal set; }
+
+        /// <summary>
+        ///     Gets the parsed arguments.
+        /// </summary>
+        public IReadOnlyList<object> Arguments
+        {
+            get
+            {
+                var arguments = _arguments;
+                return arguments == null
+                    ? (_arguments = new ReadOnlyCollection<object>(InternalArguments))
+                    : arguments;
+            }
+        }
+        private ReadOnlyCollection<object> _arguments;
+
+        internal object[] InternalArguments { get; set; }
+    }
+}

--- a/src/Qmmands/Context/CommandContext.cs
+++ b/src/Qmmands/Context/CommandContext.cs
@@ -5,7 +5,7 @@ using System.Collections.ObjectModel;
 namespace Qmmands
 {
     /// <summary>
-    ///     The interface for custom command contexts.
+    ///     The base class for custom command contexts.
     /// </summary>
     public abstract class CommandContext
     {

--- a/src/Qmmands/Context/ICommandContext.cs
+++ b/src/Qmmands/Context/ICommandContext.cs
@@ -1,8 +1,0 @@
-﻿namespace Qmmands
-{
-    /// <summary>
-    ///     The interface for custom command contexts.
-    /// </summary>
-    public interface ICommandContext
-    { }
-}

--- a/src/Qmmands/Cooldown/CooldownBucket.cs
+++ b/src/Qmmands/Cooldown/CooldownBucket.cs
@@ -7,10 +7,8 @@ namespace Qmmands
     {
         public Cooldown Cooldown { get; }
 
+        public int Remaining => Volatile.Read(ref _remaining);
         private int _remaining;
-
-        public int Remaining
-            => Volatile.Read(ref _remaining);
 
         public DateTimeOffset Window { get; private set; }
 

--- a/src/Qmmands/Cooldown/CooldownMap.cs
+++ b/src/Qmmands/Cooldown/CooldownMap.cs
@@ -26,9 +26,9 @@ namespace Qmmands
             }
         }
 
-        public CooldownBucket GetBucket(Cooldown cooldown, ICommandContext context, IServiceProvider provider)
+        public CooldownBucket GetBucket(Cooldown cooldown, CommandContext context, IServiceProvider provider)
         {
-            var key = _command.Service.CooldownBucketKeyGenerator(_command, cooldown.BucketType, context, provider);
+            var key = _command.Service.CooldownBucketKeyGenerator(cooldown.BucketType, context, provider);
             return key is null ? null : Buckets.GetOrAdd(key, new CooldownBucket(cooldown));
         }
     }

--- a/src/Qmmands/Delegates.cs
+++ b/src/Qmmands/Delegates.cs
@@ -11,7 +11,13 @@ namespace Qmmands
     /// <returns>
     ///     An <see cref="IResult"/>.
     /// </returns>
-    public delegate Task<IResult> CommandCallbackDelegate(CommandContext context, IServiceProvider provider);
+    public delegate
+#if NETCOREAPP
+        ValueTask<IResult>
+#else
+        Task<IResult>
+#endif
+        CommandCallbackDelegate(CommandContext context, IServiceProvider provider);
 
     /// <summary>
     ///     Represents a <see cref="Cooldown"/> bucket key generator callback method.

--- a/src/Qmmands/Delegates.cs
+++ b/src/Qmmands/Delegates.cs
@@ -46,5 +46,11 @@ namespace Qmmands
     /// <param name="provider"> The <see cref="IServiceProvider"/> used for execution. </param>
     public delegate Task CommandErroredDelegate(ExecutionFailedResult result, CommandContext context, IServiceProvider provider);
 
-    internal delegate bool TryParseDelegate<T>(string value, out T result);
+    internal delegate bool TryParseDelegate<T>(
+#if NETCOREAPP
+        ReadOnlySpan<char> value,
+#else
+        string value,
+#endif
+        out T result);
 }

--- a/src/Qmmands/Delegates.cs
+++ b/src/Qmmands/Delegates.cs
@@ -6,43 +6,39 @@ namespace Qmmands
     /// <summary>
     ///     Represents a <see cref="Command"/> callback method.
     /// </summary>
-    /// <param name="command"> The currently executed <see cref="Command"/>. </param>
-    /// <param name="arguments"> The parsed arguments. </param>
-    /// <param name="context"> The <see cref="ICommandContext"/> used for execution. </param>
+    /// <param name="context"> The <see cref="CommandContext"/> used for execution. </param>
     /// <param name="provider"> The <see cref="IServiceProvider"/> used for execution. </param>
     /// <returns>
     ///     An <see cref="IResult"/>.
     /// </returns>
-    public delegate Task<IResult> CommandCallbackDelegate(Command command, object[] arguments, ICommandContext context, IServiceProvider provider);
+    public delegate Task<IResult> CommandCallbackDelegate(CommandContext context, IServiceProvider provider);
 
     /// <summary>
     ///     Represents a <see cref="Cooldown"/> bucket key generator callback method.
     /// </summary>
-    /// <param name="command"> The <see cref="Command"/> to generate the bucket key for. </param>
     /// <param name="bucketType"> The <see langword="enum"/> bucket type. </param>
-    /// <param name="context"> The <see cref="ICommandContext"/> used for execution. </param>
+    /// <param name="context"> The <see cref="CommandContext"/> used for execution. </param>
     /// <param name="provider"> The <see cref="IServiceProvider"/> used for execution. </param>
     /// <returns>
     ///     A <see cref="Cooldown"/> bucket key.
     /// </returns>
-    public delegate object CooldownBucketKeyGeneratorDelegate(Command command, object bucketType, ICommandContext context, IServiceProvider provider);
+    public delegate object CooldownBucketKeyGeneratorDelegate(object bucketType, CommandContext context, IServiceProvider provider);
 
     /// <summary>
     ///     Represents a <see cref="CommandService.CommandExecuted"/> callback method.
     /// </summary>
-    /// <param name="command"> The executed <see cref="Command"/>. </param>
     /// <param name="result"> The <see cref="CommandResult"/> of the command. <see langword="null"/> if the <see cref="Command"/> did not return anything. </param>
-    /// <param name="context"> The <see cref="ICommandContext"/> used for execution. </param>
+    /// <param name="context"> The <see cref="CommandContext"/> used for execution. </param>
     /// <param name="provider"> The <see cref="IServiceProvider"/> used for execution. </param>
-    public delegate Task CommandExecutedDelegate(Command command, CommandResult result, ICommandContext context, IServiceProvider provider);
+    public delegate Task CommandExecutedDelegate(CommandResult result, CommandContext context, IServiceProvider provider);
 
     /// <summary>
     ///     Represents a <see cref="CommandService.CommandErrored"/> callback method.
     /// </summary>
     /// <param name="result"> The <see cref="ExecutionFailedResult"/> returned from execution. </param>
-    /// <param name="context"> The <see cref="ICommandContext"/> used for execution. </param>
+    /// <param name="context"> The <see cref="CommandContext"/> used for execution. </param>
     /// <param name="provider"> The <see cref="IServiceProvider"/> used for execution. </param>
-    public delegate Task CommandErroredDelegate(ExecutionFailedResult result, ICommandContext context, IServiceProvider provider);
+    public delegate Task CommandErroredDelegate(ExecutionFailedResult result, CommandContext context, IServiceProvider provider);
 
     internal delegate bool TryParseDelegate<T>(string value, out T result);
 }

--- a/src/Qmmands/ICommandService.cs
+++ b/src/Qmmands/ICommandService.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace Qmmands
 {
     /// <summary>
-    ///     Represents extracted interface from <see cref="CommandService"/>.
+    ///     Represents the extracted interface from <see cref="CommandService"/>.
     /// </summary>
     public interface ICommandService
     {

--- a/src/Qmmands/ICommandService.cs
+++ b/src/Qmmands/ICommandService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace Qmmands
 {
     /// <summary>
-    ///     Provides a framework interface for creating text based commands.
+    ///     Represents extracted interface from <see cref="CommandService"/>.
     /// </summary>
     public interface ICommandService
     {

--- a/src/Qmmands/ICommandService.cs
+++ b/src/Qmmands/ICommandService.cs
@@ -101,15 +101,6 @@ namespace Qmmands
         IReadOnlyList<Module> AddModules(Assembly assembly, Predicate<TypeInfo> predicate = null, Action<ModuleBuilder> action = null);
 
         /// <summary>
-        ///     Attempts to build the specified <see cref="ModuleBuilder"/> into a <see cref="Module"/>.
-        /// </summary>
-        /// <param name="builder"> The builder to build. </param>
-        /// <returns>
-        ///     A <see cref="Module"/>.
-        /// </returns>
-        Module AddModule(ModuleBuilder builder);
-
-        /// <summary>
         ///     Attempts to instantiate, modify, and build a <see cref="ModuleBuilder"/> into a <see cref="Module"/>.
         /// </summary>
         /// <param name="action"> The action to perform on the builder. </param>

--- a/src/Qmmands/ICommandService.cs
+++ b/src/Qmmands/ICommandService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -10,6 +10,51 @@ namespace Qmmands
     /// </summary>
     public interface ICommandService
     {
+        /// <summary>
+        ///     Gets whether <see cref="FindModules"/>, <see cref="FindCommands"/> and primitive <see langword="enum"/> type parsers are case sensitive or not.
+        /// </summary>
+        bool IsCaseSensitive { get; }
+
+        /// <summary>
+        ///     Gets the default <see cref="RunMode"/> for commands and modules.
+        /// </summary>
+        RunMode DefaultRunMode { get; }
+
+        /// <summary>
+        ///     Gets whether commands should ignore extra arguments by default or not.
+        /// </summary>
+        bool IgnoresExtraArguments { get; }
+
+        /// <summary>
+        ///     Gets the separator.
+        /// </summary>
+        string Separator { get; }
+
+        /// <summary>
+        ///     Gets the separator requirement.
+        /// </summary>
+        SeparatorRequirement SeparatorRequirement { get; }
+
+        /// <summary>
+        ///     Gets the default argument parser.
+        /// </summary>
+        IArgumentParser ArgumentParser { get; }
+
+        /// <summary>
+        ///     Gets the generator <see langword="delegate"/> to use for <see cref="Cooldown"/> bucket keys.
+        /// </summary>
+        CooldownBucketKeyGeneratorDelegate CooldownBucketKeyGenerator { get; }
+
+        /// <summary>
+        ///     Gets the quotation mark map used for non-remainder multi word arguments.
+        /// </summary>
+        IReadOnlyDictionary<char, char> QuotationMarkMap { get; }
+
+        /// <summary>
+        ///     Gets the collection of nouns used for nullable value type parsing.
+        /// </summary>
+        IReadOnlyList<string> NullableNouns { get; }
+
         /// <summary>
         ///     Fires when a command is successfully executed. Use this to handle <see cref="RunMode.Parallel"/> commands.
         /// </summary>

--- a/src/Qmmands/ICommandService.cs
+++ b/src/Qmmands/ICommandService.cs
@@ -115,6 +115,11 @@ namespace Qmmands
         void RemoveTypeParser<T>(TypeParser<T> parser);
 
         /// <summary>
+        ///     Removes all added <see cref="TypeParser{T}"/>s.
+        /// </summary>
+        void RemoveAllTypeParsers();
+
+        /// <summary>
         ///     Retrieves a <see cref="TypeParser{T}"/> from the added non-primitive parsers for the specified <typeparamref name="T"/> <see cref="Type"/>.
         /// </summary>
         /// <typeparam name="T"> The <see cref="Type"/> the <see cref="TypeParser{T}"/> is for. </typeparam>

--- a/src/Qmmands/ICommandService.cs
+++ b/src/Qmmands/ICommandService.cs
@@ -159,23 +159,23 @@ namespace Qmmands
         ///     Attempts to find <see cref="Command"/>s matching the input and executes the most suitable one.
         /// </summary>
         /// <param name="input"> The input. </param>
-        /// <param name="context"> The <see cref="ICommandContext"/> to use during execution. </param>
+        /// <param name="context"> The <see cref="CommandContext"/> to use during execution. </param>
         /// <param name="provider"> The <see cref="IServiceProvider"/> to use during execution. </param>
         /// <returns>
         ///     An <see cref="IResult"/>.
         /// </returns>
-        Task<IResult> ExecuteAsync(string input, ICommandContext context, IServiceProvider provider = null);
+        Task<IResult> ExecuteAsync(string input, CommandContext context, IServiceProvider provider = null);
 
         /// <summary>
         ///     Attempts to parse the arguments for the provided <see cref="Command"/> and execute it.
         /// </summary>
         /// <param name="command"> The <see cref="Command"/> to execute. </param>
         /// <param name="rawArguments"> The raw arguments to use for this <see cref="Command"/>'s parameters. </param>
-        /// <param name="context"> The <see cref="ICommandContext"/> to use during execution. </param>
+        /// <param name="context"> The <see cref="CommandContext"/> to use during execution. </param>
         /// <param name="provider"> The <see cref="IServiceProvider"/> to use during execution. </param>
         /// <returns>
         ///     An <see cref="IResult"/>.
         /// </returns>
-        Task<IResult> ExecuteAsync(Command command, string rawArguments, ICommandContext context, IServiceProvider provider = null);
+        Task<IResult> ExecuteAsync(Command command, string rawArguments, CommandContext context, IServiceProvider provider = null);
     }
 }

--- a/src/Qmmands/Mapping/CommandMap.cs
+++ b/src/Qmmands/Mapping/CommandMap.cs
@@ -43,14 +43,27 @@ namespace Qmmands
             {
                 for (var i = 0; i < module.Aliases.Count; i++)
                 {
-                    path.Add(module.Aliases[i]);
-                    MapCommands(module, path);
+                    var alias = module.Aliases[i];
+                    if (alias.Length == 0)
+                    {
+                        MapCommands(module, path);
 
-                    for (var j = 0; j < module.Submodules.Count; j++)
-                        MapModule(module.Submodules[j], path);
+                        for (var j = 0; j < module.Submodules.Count; j++)
+                            MapModule(module.Submodules[j], path);
 
-                    AddModule(module, path);
-                    path.RemoveAt(path.Count - 1);
+                        AddModule(module, path);
+                    }
+                    else
+                    {
+                        path.Add(alias);
+                        MapCommands(module, path);
+
+                        for (var j = 0; j < module.Submodules.Count; j++)
+                            MapModule(module.Submodules[j], path);
+
+                        AddModule(module, path);
+                        path.RemoveAt(path.Count - 1);
+                    }
                 }
             }
         }
@@ -71,14 +84,27 @@ namespace Qmmands
             {
                 for (var i = 0; i < module.Aliases.Count; i++)
                 {
-                    path.Add(module.Aliases[i]);
-                    UnmapCommands(module, path);
+                    var alias = module.Aliases[i];
+                    if (alias.Length == 0)
+                    {
+                        UnmapCommands(module, path);
 
-                    for (var j = 0; j < module.Submodules.Count; j++)
-                        UnmapModule(module.Submodules[j], path);
+                        for (var j = 0; j < module.Submodules.Count; j++)
+                            UnmapModule(module.Submodules[j], path);
 
-                    RemoveModule(module, path);
-                    path.RemoveAt(path.Count - 1);
+                        RemoveModule(module, path);
+                    }
+                    else
+                    {
+                        path.Add(alias);
+                        UnmapCommands(module, path);
+
+                        for (var j = 0; j < module.Submodules.Count; j++)
+                            UnmapModule(module.Submodules[j], path);
+
+                        RemoveModule(module, path);
+                        path.RemoveAt(path.Count - 1);
+                    }
                 }
             }
         }
@@ -94,9 +120,20 @@ namespace Qmmands
                 {
                     for (var i = 0; i < command.Aliases.Count; i++)
                     {
-                        path.Add(command.Aliases[i]);
-                        AddCommand(command, path);
-                        path.RemoveAt(path.Count - 1);
+                        var alias = command.Aliases[i];
+                        if (alias.Length == 0)
+                        {
+                            if (path.Count == 0)
+                                continue;
+
+                            AddCommand(command, path);
+                        }
+                        else
+                        {
+                            path.Add(alias);
+                            AddCommand(command, path);
+                            path.RemoveAt(path.Count - 1);
+                        }
                     }
                 }
             }
@@ -113,9 +150,20 @@ namespace Qmmands
                 {
                     for (var i = 0; i < command.Aliases.Count; i++)
                     {
-                        path.Add(command.Aliases[i]);
-                        RemoveCommand(command, path);
-                        path.RemoveAt(path.Count - 1);
+                        var alias = command.Aliases[i];
+                        if (alias.Length == 0)
+                        {
+                            if (path.Count == 0)
+                                continue;
+
+                            RemoveCommand(command, path);
+                        }
+                        else
+                        {
+                            path.Add(alias);
+                            RemoveCommand(command, path);
+                            path.RemoveAt(path.Count - 1);
+                        }
                     }
                 }
             }

--- a/src/Qmmands/Mapping/CommandMap.cs
+++ b/src/Qmmands/Mapping/CommandMap.cs
@@ -4,10 +4,10 @@ namespace Qmmands
 {
     internal sealed class CommandMap
     {
-        private readonly CommandNode _rootNode;
+        private readonly CommandMapNode _rootNode;
 
         public CommandMap(CommandService service)
-            => _rootNode = new CommandNode(service);
+            => _rootNode = new CommandMapNode(service);
 
         public IEnumerable<CommandMatch> FindCommands(string text)
             => _rootNode.FindCommands(new List<string>(), text, 0);
@@ -27,7 +27,10 @@ namespace Qmmands
         public void RemoveCommand(Command command, IReadOnlyList<string> path)
             => _rootNode.RemoveCommand(command, path, 0);
 
-        public void MapModule(Module module, List<string> path)
+        public void MapModule(Module module)
+            => MapModule(module, new List<string>());
+
+        private void MapModule(Module module, List<string> path)
         {
             if (module.Aliases.Count == 0)
             {
@@ -68,7 +71,10 @@ namespace Qmmands
             }
         }
 
-        public void UnmapModule(Module module, List<string> path)
+        public void UnmapModule(Module module)
+            => UnmapModule(module, new List<string>());
+
+        private void UnmapModule(Module module, List<string> path)
         {
             if (module.Aliases.Count == 0)
             {

--- a/src/Qmmands/Mapping/CommandMapNode.cs
+++ b/src/Qmmands/Mapping/CommandMapNode.cs
@@ -14,9 +14,9 @@ namespace Qmmands
         public CommandMapNode(CommandService service)
         {
             _service = service;
-            _commands = new Dictionary<string, List<Command>>(_service.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
-            _modules = new Dictionary<string, List<Module>>(_service.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
-            _nodes = new Dictionary<string, CommandMapNode>(_service.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
+            _commands = new Dictionary<string, List<Command>>(_service.IsCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
+            _modules = new Dictionary<string, List<Module>>(_service.IsCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
+            _nodes = new Dictionary<string, CommandMapNode>(_service.IsCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
             _isNullOrWhitespaceSeparator = string.IsNullOrWhiteSpace(_service.Separator);
         }
 
@@ -213,7 +213,7 @@ namespace Qmmands
                             if (signature.HasRemainder == otherSignature.HasRemainder)
                                 throw new CommandMappingException(command, segment, "Cannot map multiple overloads with the same signature.");
 
-                            else if (!signature.HasRemainder && command.IgnoreExtraArguments || !otherSignature.HasRemainder && otherCommand.IgnoreExtraArguments)
+                            else if (!signature.HasRemainder && command.IgnoresExtraArguments || !otherSignature.HasRemainder && otherCommand.IgnoresExtraArguments)
                                 throw new CommandMappingException(command, segment, "Cannot map multiple overloads with the same argument types, with one of them being a remainder, if the other one ignores extra arguments.");
                         }
                     }

--- a/src/Qmmands/Mapping/CommandMapNode.cs
+++ b/src/Qmmands/Mapping/CommandMapNode.cs
@@ -3,20 +3,20 @@ using System.Collections.Generic;
 
 namespace Qmmands
 {
-    internal sealed class CommandNode
+    internal sealed class CommandMapNode
     {
         private readonly CommandService _service;
         private readonly Dictionary<string, List<Command>> _commands;
         private readonly Dictionary<string, List<Module>> _modules;
-        private readonly Dictionary<string, CommandNode> _nodes;
+        private readonly Dictionary<string, CommandMapNode> _nodes;
         private readonly bool _isNullOrWhitespaceSeparator;
 
-        public CommandNode(CommandService service)
+        public CommandMapNode(CommandService service)
         {
             _service = service;
             _commands = new Dictionary<string, List<Command>>(_service.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
             _modules = new Dictionary<string, List<Module>>(_service.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
-            _nodes = new Dictionary<string, CommandNode>(_service.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
+            _nodes = new Dictionary<string, CommandMapNode>(_service.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
             _isNullOrWhitespaceSeparator = string.IsNullOrWhiteSpace(_service.Separator);
         }
 
@@ -31,10 +31,10 @@ namespace Qmmands
                 if (index == -1 || !(hasWhitespaceSeparator || string.IsNullOrWhiteSpace(arguments)))
                     continue;
 
-                foreach (var command in kvp.Value)
+                for (var i = 0; i < kvp.Value.Count; i++)
                 {
                     path.Add(kvp.Key);
-                    yield return new CommandMatch(command, kvp.Key, path, arguments);
+                    yield return new CommandMatch(kvp.Value[i], kvp.Key, path, arguments);
                     path.RemoveAt(path.Count - 1);
                 }
             }
@@ -63,10 +63,10 @@ namespace Qmmands
                 if (index == -1 || !(hasWhitespaceSeparator || string.IsNullOrWhiteSpace(arguments)))
                     continue;
 
-                foreach (var module in kvp.Value)
+                for (var i = 0; i < kvp.Value.Count; i++)
                 {
                     path.Add(kvp.Key);
-                    yield return new ModuleMatch(module, kvp.Key, path, arguments);
+                    yield return new ModuleMatch(kvp.Value[i], kvp.Key, path, arguments);
                     path.RemoveAt(path.Count - 1);
                 }
             }
@@ -94,7 +94,6 @@ namespace Qmmands
                 hasWhitespaceSeparator = false;
                 return -1;
             }
-
             else
             {
                 index += key.Length;
@@ -170,7 +169,7 @@ namespace Qmmands
             {
                 if (!_nodes.TryGetValue(segment, out var node))
                 {
-                    node = new CommandNode(_service);
+                    node = new CommandMapNode(_service);
                     _nodes.Add(segment, node);
                 }
 
@@ -230,7 +229,7 @@ namespace Qmmands
             {
                 if (!_nodes.TryGetValue(segment, out var node))
                 {
-                    node = new CommandNode(_service);
+                    node = new CommandMapNode(_service);
                     _nodes.Add(segment, node);
                 }
 

--- a/src/Qmmands/Mapping/CommandMatch.cs
+++ b/src/Qmmands/Mapping/CommandMatch.cs
@@ -19,7 +19,7 @@ namespace Qmmands
         public string Alias { get; }
 
         /// <summary>
-        ///     Gets the path to the found <see cref="Qmmands.Command"/>.
+        ///     Gets the alias path to the found <see cref="Qmmands.Command"/>.
         /// </summary>
         public IReadOnlyList<string> Path { get; }
 

--- a/src/Qmmands/Mapping/ModuleMatch.cs
+++ b/src/Qmmands/Mapping/ModuleMatch.cs
@@ -19,7 +19,7 @@ namespace Qmmands
         public string Alias { get; }
 
         /// <summary>
-        ///     Gets the path to the found <see cref="Qmmands.Module"/>.
+        ///     Gets the alias path to the found <see cref="Qmmands.Module"/>.
         /// </summary>
         public IReadOnlyList<string> Path { get; }
 

--- a/src/Qmmands/ModuleBases/IModuleBase.cs
+++ b/src/Qmmands/ModuleBases/IModuleBase.cs
@@ -4,10 +4,10 @@ namespace Qmmands
 {
     internal interface IModuleBase
     {
-        Task BeforeExecutedAsync(Command command);
+        Task BeforeExecutedAsync();
 
-        Task AfterExecutedAsync(Command command);
+        Task AfterExecutedAsync();
 
-        void Prepare(ICommandContext context);
+        void Prepare(CommandContext context);
     }
 }

--- a/src/Qmmands/ModuleBases/ModuleBase.cs
+++ b/src/Qmmands/ModuleBases/ModuleBase.cs
@@ -6,9 +6,9 @@ namespace Qmmands
     /// <summary>
     ///     Makes the inheriting class a <see cref="Module"/> that can be added to the <see cref="CommandService"/>.
     /// </summary>
-    /// <typeparam name="TContext"> The <see cref="ICommandContext"/> this <see cref="Module"/> will use. </typeparam>
+    /// <typeparam name="TContext"> The <see cref="CommandContext"/> this <see cref="Module"/> will use. </typeparam>
     public abstract class ModuleBase<TContext> : IModuleBase
-        where TContext : class, ICommandContext
+        where TContext : CommandContext
     {
         /// <summary>
         ///     The command context.
@@ -18,27 +18,25 @@ namespace Qmmands
         /// <summary>
         ///     Fires before a <see cref="Command"/> in this <see cref="Module"/> is executed.
         /// </summary>
-        /// <param name="command"> The about to be executed <see cref="Command"/>. </param>
-        protected virtual Task BeforeExecutedAsync(Command command)
+        protected virtual Task BeforeExecutedAsync()
             => Task.CompletedTask;
 
         /// <summary>
         ///     Fires after a <see cref="Command"/> in this <see cref="Module"/> is executed.
         /// </summary>
-        /// <param name="command"> The executed <see cref="Command"/>. </param>
-        protected virtual Task AfterExecutedAsync(Command command)
+        protected virtual Task AfterExecutedAsync()
             => Task.CompletedTask;
 
-        internal void Prepare(ICommandContext context)
+        internal void Prepare(CommandContext context) 
             => Context = context as TContext ?? throw new InvalidOperationException($"Unable to set the context. Expected {typeof(TContext)}, got {context.GetType()}.");
 
-        Task IModuleBase.BeforeExecutedAsync(Command command)
-            => BeforeExecutedAsync(command);
+        Task IModuleBase.BeforeExecutedAsync()
+            => BeforeExecutedAsync();
 
-        Task IModuleBase.AfterExecutedAsync(Command command)
-            => AfterExecutedAsync(command);
+        Task IModuleBase.AfterExecutedAsync()
+            => AfterExecutedAsync();
 
-        void IModuleBase.Prepare(ICommandContext context)
+        void IModuleBase.Prepare(CommandContext context)
             => Prepare(context);
     }
 }

--- a/src/Qmmands/Parsing/DefaultArgumentParser.cs
+++ b/src/Qmmands/Parsing/DefaultArgumentParser.cs
@@ -1,30 +1,37 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Text;
 
 namespace Qmmands
 {
     /// <summary>
-    ///     The default argument parser used by the <see cref="CommandService"/>.
+    ///     Represents the default argument parser used by the <see cref="CommandService"/>.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class DefaultArgumentParser : IArgumentParser
     {
         /// <summary>
-        ///     Attempts to parse raw arguments for the specified <see cref="Command"/>.
+        ///     Gets the singleton instance of the <see cref="DefaultArgumentParser"/>.
         /// </summary>
-        /// <param name="command"> The <see cref="Command"/> to parse raw arguments for. </param>
-        /// <param name="rawArguments"> The raw arguments. </param>
+        public static readonly DefaultArgumentParser Instance = new DefaultArgumentParser();
+
+        private DefaultArgumentParser()
+        { }
+
+        /// <summary>
+        ///     Attempts to parse raw arguments for the given <see cref="CommandContext"/>.
+        /// </summary>
+        /// <param name="context"> The <see cref="CommandContext"/> to parse raw arguments for. </param>
         /// <returns>
         ///     An <see cref="ArgumentParserResult"/>.
         /// </returns>
-        public ArgumentParserResult ParseRawArguments(Command command, string rawArguments)
+        public ArgumentParserResult Parse(CommandContext context)
         {
+            var command = context.Command;
+            var rawArguments = context.RawArguments;
             Parameter currentParameter = null;
             Parameter multipleParameter = null;
             var argumentBuilder = new StringBuilder();
-            var arguments = new Dictionary<Parameter, object>();
+            var arguments = new Dictionary<Parameter, object>(command.Parameters.Count);
             var currentQuote = '\0';
             var expectedQuote = '\0';
             var whitespaceSeparated = false;

--- a/src/Qmmands/Parsing/DefaultArgumentParser.cs
+++ b/src/Qmmands/Parsing/DefaultArgumentParser.cs
@@ -68,7 +68,7 @@ namespace Qmmands
                         currentParameter = arguments.Count < command.Parameters.Count && command.Parameters.Count > 0 ? command.Parameters[arguments.Count] : multipleParameter;
                         if (currentParameter == null)
                         {
-                            if (command.IgnoreExtraArguments)
+                            if (command.IgnoresExtraArguments)
                                 break;
 
                             else

--- a/src/Qmmands/Parsing/DefaultArgumentParser.cs
+++ b/src/Qmmands/Parsing/DefaultArgumentParser.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if NETCOREAPP
+using System;
+#endif
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -73,7 +75,7 @@ namespace Qmmands
                     }
 
                     else if (currentPosition != 0 && !whitespaceSeparated)
-                        return new ArgumentParserResult(command, null, context.RawArguments, arguments, command.Service.QuotationMarkMap.TryGetValue(character, out expectedQuote) 
+                        return new ArgumentParserResult(command, null, context.RawArguments, arguments, command.Service.QuotationMarkMap.TryGetValue(character, out expectedQuote)
                             &&
 #if NETCOREAPP
                             rawArguments.Slice(currentPosition + 1).IndexOf(expectedQuote)
@@ -103,7 +105,7 @@ namespace Qmmands
                 {
                     argumentBuilder.Append(
 #if NETCOREAPP
-                        rawArguments.Slice(currentPosition) 
+                        rawArguments.Slice(currentPosition)
 #else
                         rawArguments.Substring(currentPosition)
 #endif
@@ -139,7 +141,7 @@ namespace Qmmands
                         if (currentPosition != 0 && !whitespaceSeparated)
                             return new ArgumentParserResult(command, currentParameter, context.RawArguments, arguments,
 #if NETCOREAPP
-                                rawArguments.Slice(currentPosition + 1).IndexOf(expectedQuote) 
+                                rawArguments.Slice(currentPosition + 1).IndexOf(expectedQuote)
 #else
                                 rawArguments.IndexOf(expectedQuote, currentPosition + 1)
 #endif

--- a/src/Qmmands/Parsing/IArgumentParser.cs
+++ b/src/Qmmands/Parsing/IArgumentParser.cs
@@ -1,18 +1,17 @@
 ﻿namespace Qmmands
 {
     /// <summary>
-    ///     The default interface for raw argument parsers.
+    ///     Represents the interface for raw argument parsers.
     /// </summary>
     public interface IArgumentParser
     {
         /// <summary>
-        ///     Attempts to parse raw arguments for the specified <see cref="Command"/>.
+        ///     Attempts to parse raw arguments for the given <see cref="CommandContext"/>.
         /// </summary>
-        /// <param name="command"> The <see cref="Command"/> to parse raw arguments for. </param>
-        /// <param name="rawArguments"> The raw arguments. </param>
+        /// <param name="context"> The <see cref="CommandContext"/> to parse raw arguments for. </param>
         /// <returns>
         ///     An <see cref="ArgumentParserResult"/>.
         /// </returns>
-        ArgumentParserResult ParseRawArguments(Command command, string rawArguments);
+        ArgumentParserResult Parse(CommandContext context);
     }
 }

--- a/src/Qmmands/Parsing/Parsers/ITypeParser.cs
+++ b/src/Qmmands/Parsing/Parsers/ITypeParser.cs
@@ -5,6 +5,11 @@ namespace Qmmands
 {
     internal interface ITypeParser
     {
-        Task<TypeParserResult<object>> ParseAsync(Parameter parameter, string value, CommandContext context, IServiceProvider provider);
+#if NETCOREAPP
+        ValueTask<TypeParserResult<object>>
+#else
+        Task<TypeParserResult<object>>
+#endif
+        ParseAsync(Parameter parameter, string value, CommandContext context, IServiceProvider provider);
     }
 }

--- a/src/Qmmands/Parsing/Parsers/ITypeParser.cs
+++ b/src/Qmmands/Parsing/Parsers/ITypeParser.cs
@@ -5,6 +5,6 @@ namespace Qmmands
 {
     internal interface ITypeParser
     {
-        Task<TypeParserResult<object>> ParseAsync(Parameter parameter, string value, ICommandContext context, IServiceProvider provider);
+        Task<TypeParserResult<object>> ParseAsync(Parameter parameter, string value, CommandContext context, IServiceProvider provider);
     }
 }

--- a/src/Qmmands/Parsing/Parsers/NullableTypeParser.cs
+++ b/src/Qmmands/Parsing/Parsers/NullableTypeParser.cs
@@ -14,9 +14,18 @@ namespace Qmmands
             _typeParser = typeParser;
         }
 
-        public override Task<TypeParserResult<T>> ParseAsync(Parameter parameter, string value, CommandContext context, IServiceProvider provider)
+#if NETCOREAPP
+        public override ValueTask<TypeParserResult<T>>
+#else
+        public override Task<TypeParserResult<T>>
+#endif
+        ParseAsync(Parameter parameter, string value, CommandContext context, IServiceProvider provider)
             => parameter.Service.NullableNouns.Any(x => value.Equals(x, parameter.Service.StringComparison))
+#if NETCOREAPP
+                ? new ValueTask<TypeParserResult<T>>(new TypeParserResult<T>(false))
+#else
                 ? Task.FromResult(new TypeParserResult<T>(false))
+#endif
                 : _typeParser.ParseAsync(parameter, value, context, provider);
     }
 }

--- a/src/Qmmands/Parsing/Parsers/NullableTypeParser.cs
+++ b/src/Qmmands/Parsing/Parsers/NullableTypeParser.cs
@@ -14,7 +14,7 @@ namespace Qmmands
             _typeParser = typeParser;
         }
 
-        public override Task<TypeParserResult<T>> ParseAsync(Parameter parameter, string value, ICommandContext context, IServiceProvider provider)
+        public override Task<TypeParserResult<T>> ParseAsync(Parameter parameter, string value, CommandContext context, IServiceProvider provider)
             => parameter.Service.NullableNouns.Any(x => value.Equals(x, parameter.Service.StringComparison))
                 ? Task.FromResult(new TypeParserResult<T>(false))
                 : _typeParser.ParseAsync(parameter, value, context, provider);

--- a/src/Qmmands/Parsing/Parsers/TypeParser.cs
+++ b/src/Qmmands/Parsing/Parsers/TypeParser.cs
@@ -17,9 +17,20 @@ namespace Qmmands
         /// <param name="context"> The <see cref="CommandContext"/> used during execution. </param>
         /// <param name="provider"> The <see cref="IServiceProvider"/> used during execution. </param>
         /// <returns> A <see cref="TypeParserResult{T}"/>. </returns>
-        public abstract Task<TypeParserResult<T>> ParseAsync(Parameter parameter, string value, CommandContext context, IServiceProvider provider);
+        public abstract
+#if NETCOREAPP
+        ValueTask<TypeParserResult<T>>
+#else
+        Task<TypeParserResult<T>>
+#endif
+        ParseAsync(Parameter parameter, string value, CommandContext context, IServiceProvider provider);
 
-        async Task<TypeParserResult<object>> ITypeParser.ParseAsync(Parameter parameter, string value, CommandContext context, IServiceProvider provider)
+#if NETCOREAPP
+        async ValueTask<TypeParserResult<object>>
+#else
+        async Task<TypeParserResult<object>>
+#endif
+        ITypeParser.ParseAsync(Parameter parameter, string value, CommandContext context, IServiceProvider provider)
         {
             var result = await ParseAsync(parameter, value, context, provider).ConfigureAwait(false);
             return result.IsSuccessful

--- a/src/Qmmands/Parsing/Parsers/TypeParser.cs
+++ b/src/Qmmands/Parsing/Parsers/TypeParser.cs
@@ -14,12 +14,12 @@ namespace Qmmands
         /// </summary>
         /// <param name="parameter"> The currently parsed <see cref="Parameter"/>. </param>
         /// <param name="value"> The raw argument to parse. </param>
-        /// <param name="context"> The <see cref="ICommandContext"/> used during execution. </param>
+        /// <param name="context"> The <see cref="CommandContext"/> used during execution. </param>
         /// <param name="provider"> The <see cref="IServiceProvider"/> used during execution. </param>
         /// <returns> A <see cref="TypeParserResult{T}"/>. </returns>
-        public abstract Task<TypeParserResult<T>> ParseAsync(Parameter parameter, string value, ICommandContext context, IServiceProvider provider);
+        public abstract Task<TypeParserResult<T>> ParseAsync(Parameter parameter, string value, CommandContext context, IServiceProvider provider);
 
-        async Task<TypeParserResult<object>> ITypeParser.ParseAsync(Parameter parameter, string value, ICommandContext context, IServiceProvider provider)
+        async Task<TypeParserResult<object>> ITypeParser.ParseAsync(Parameter parameter, string value, CommandContext context, IServiceProvider provider)
         {
             var result = await ParseAsync(parameter, value, context, provider).ConfigureAwait(false);
             return result.IsSuccessful

--- a/src/Qmmands/Qmmands.csproj
+++ b/src/Qmmands/Qmmands.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>2.3.1</VersionPrefix>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <VersionPrefix>3.0.0</VersionPrefix>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.2</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Quahu</Authors>

--- a/src/Qmmands/Qmmands.csproj
+++ b/src/Qmmands/Qmmands.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Quahu</Authors>

--- a/src/Qmmands/ReflectionUtilities.cs
+++ b/src/Qmmands/ReflectionUtilities.cs
@@ -198,6 +198,9 @@ namespace Qmmands
 
                     case OverrideTypeParserAttribute overwriteTypeParserAttribute:
                         builder.CustomTypeParserType = overwriteTypeParserAttribute.CustomTypeParserType;
+
+                        if (overwriteTypeParserAttribute.GetType() != typeof(OverrideTypeParserAttribute))
+                            builder.AddAttribute(overwriteTypeParserAttribute);
                         break;
 
                     case ParameterCheckBaseAttribute parameterCheckAttribute:

--- a/src/Qmmands/ReflectionUtilities.cs
+++ b/src/Qmmands/ReflectionUtilities.cs
@@ -449,7 +449,12 @@ namespace Qmmands
         {
             TryParseDelegates = new Dictionary<Type, Delegate>(13)
             {
-                [typeof(char)] = (TryParseDelegate<char>) char.TryParse,
+                [typeof(char)] =
+#if NETCOREAPP
+                    (TryParseDelegate<char>) TryParseChar,
+#else
+                    (TryParseDelegate<char>) char.TryParse,
+#endif
                 [typeof(bool)] = (TryParseDelegate<bool>) bool.TryParse,
                 [typeof(byte)] = (TryParseDelegate<byte>) byte.TryParse,
                 [typeof(sbyte)] = (TryParseDelegate<sbyte>) sbyte.TryParse,
@@ -464,5 +469,18 @@ namespace Qmmands
                 [typeof(decimal)] = (TryParseDelegate<decimal>) decimal.TryParse
             };
         }
+#if NETCOREAPP
+        private static bool TryParseChar(ReadOnlySpan<char> value, out char result)
+        {
+            if (value.Length == 1)
+            {
+                result = value[0];
+                return true;
+            }
+
+            result = default;
+            return false;
+        }
+#endif
     }
 }

--- a/src/Qmmands/ReflectionUtilities.cs
+++ b/src/Qmmands/ReflectionUtilities.cs
@@ -78,7 +78,7 @@ namespace Qmmands
                         break;
 
                     case IgnoreExtraArgumentsAttribute ignoreExtraArgumentsAttribute:
-                        builder.IgnoreExtraArguments = ignoreExtraArgumentsAttribute.IgnoreExtraArguments;
+                        builder.WithIgnoreExtraArguments(ignoreExtraArgumentsAttribute.IgnoreExtraArguments);
                         break;
 
                     case GroupAttribute groupAttribute:
@@ -197,7 +197,7 @@ namespace Qmmands
                         break;
 
                     case OverrideTypeParserAttribute overwriteTypeParserAttribute:
-                        builder.CustomTypeParserType = overwriteTypeParserAttribute.CustomTypeParserType;
+                        builder.WithCustomTypeParserType(overwriteTypeParserAttribute.CustomTypeParserType);
 
                         if (overwriteTypeParserAttribute.GetType() != typeof(OverrideTypeParserAttribute))
                             builder.AddAttribute(overwriteTypeParserAttribute);

--- a/src/Qmmands/ReflectionUtilities.cs
+++ b/src/Qmmands/ReflectionUtilities.cs
@@ -156,7 +156,7 @@ namespace Qmmands
 
             var parameters = methodInfo.GetParameters();
             for (var i = 0; i < parameters.Length; i++)
-                builder.AddParameters(CreateParameterBuilder(builder, parameters[i], i + 1 == parameters.Length));
+                builder.Parameters.Add(CreateParameterBuilder(builder, parameters[i], i + 1 == parameters.Length));
 
             return builder;
         }

--- a/src/Qmmands/ReflectionUtilities.cs
+++ b/src/Qmmands/ReflectionUtilities.cs
@@ -203,7 +203,7 @@ namespace Qmmands
                             builder.AddAttribute(overwriteTypeParserAttribute);
                         break;
 
-                    case ParameterCheckBaseAttribute parameterCheckAttribute:
+                    case ParameterCheckAttribute parameterCheckAttribute:
                         builder.AddCheck(parameterCheckAttribute);
                         break;
 

--- a/src/Qmmands/Results/Failed/Checks/ChecksFailedResult.cs
+++ b/src/Qmmands/Results/Failed/Checks/ChecksFailedResult.cs
@@ -23,16 +23,16 @@ namespace Qmmands
         /// <summary>
         ///     Gets the checks that failed with their respective results.
         /// </summary>
-        public IReadOnlyList<(CheckBaseAttribute Check, CheckResult Result)> FailedChecks { get; }
+        public IReadOnlyList<(CheckAttribute Check, CheckResult Result)> FailedChecks { get; }
 
-        internal ChecksFailedResult(Command command, IReadOnlyList<(CheckBaseAttribute Check, CheckResult Result)> failedChecks)
+        internal ChecksFailedResult(Command command, IReadOnlyList<(CheckAttribute Check, CheckResult Result)> failedChecks)
         {
             Command = command;
             FailedChecks = failedChecks;
             Reason = $"{(FailedChecks.Count == 1 ? "One check" : "Multiple checks")} failed for the command {Command}.";
         }
 
-        internal ChecksFailedResult(Module module, IReadOnlyList<(CheckBaseAttribute Check, CheckResult Result)> failedChecks)
+        internal ChecksFailedResult(Module module, IReadOnlyList<(CheckAttribute Check, CheckResult Result)> failedChecks)
         {
             Module = module;
             FailedChecks = failedChecks;

--- a/src/Qmmands/Results/Failed/Checks/ChecksFailedResult.cs
+++ b/src/Qmmands/Results/Failed/Checks/ChecksFailedResult.cs
@@ -7,7 +7,9 @@ namespace Qmmands
     /// </summary>
     public sealed class ChecksFailedResult : FailedResult
     {
-        /// <inheritdoc />
+        /// <summary>
+        ///     Gets the reason of this failed result.
+        /// </summary>
         public override string Reason { get; }
 
         /// <summary>

--- a/src/Qmmands/Results/Failed/Checks/ParameterChecksFailedResult.cs
+++ b/src/Qmmands/Results/Failed/Checks/ParameterChecksFailedResult.cs
@@ -7,7 +7,9 @@ namespace Qmmands
     /// </summary>
     public sealed class ParameterChecksFailedResult : FailedResult
     {
-        /// <inheritdoc />
+        /// <summary>
+        ///     Gets the reason of this failed result.
+        /// </summary>
         public override string Reason { get; }
 
         /// <summary>

--- a/src/Qmmands/Results/Failed/Checks/ParameterChecksFailedResult.cs
+++ b/src/Qmmands/Results/Failed/Checks/ParameterChecksFailedResult.cs
@@ -23,9 +23,9 @@ namespace Qmmands
         /// <summary>
         ///     Gets the checks that failed with their error reasons.
         /// </summary>
-        public IReadOnlyList<(ParameterCheckBaseAttribute Check, CheckResult Result)> FailedChecks { get; }
+        public IReadOnlyList<(ParameterCheckAttribute Check, CheckResult Result)> FailedChecks { get; }
 
-        internal ParameterChecksFailedResult(Parameter parameter, object argument, IReadOnlyList<(ParameterCheckBaseAttribute Check, CheckResult Result)> failedChecks)
+        internal ParameterChecksFailedResult(Parameter parameter, object argument, IReadOnlyList<(ParameterCheckAttribute Check, CheckResult Result)> failedChecks)
         {
             Parameter = parameter;
             Argument = argument;

--- a/src/Qmmands/Results/Failed/CommandNotFoundResult.cs
+++ b/src/Qmmands/Results/Failed/CommandNotFoundResult.cs
@@ -5,7 +5,9 @@
     /// </summary>
     public sealed class CommandNotFoundResult : FailedResult
     {
-        /// <inheritdoc />
+        /// <summary>
+        ///     Gets the reason of this failed result.
+        /// </summary>
         public override string Reason => "No command found matching the provided input.";
 
         internal CommandNotFoundResult()

--- a/src/Qmmands/Results/Failed/CommandOnCooldownResult.cs
+++ b/src/Qmmands/Results/Failed/CommandOnCooldownResult.cs
@@ -9,7 +9,9 @@ namespace Qmmands
     /// </summary>
     public sealed class CommandOnCooldownResult : FailedResult
     {
-        /// <inheritdoc />
+        /// <summary>
+        ///     Gets the reason of this failed result.
+        /// </summary>
         public override string Reason { get; }
 
         /// <summary>

--- a/src/Qmmands/Results/Failed/Execution/CommandExecutionStep.cs
+++ b/src/Qmmands/Results/Failed/Execution/CommandExecutionStep.cs
@@ -21,7 +21,7 @@
         TypeParsing,
 
         /// <summary>
-        ///     An exception occcured in <see cref="ModuleBase{TContext}.BeforeExecutedAsync(Command)"/>.
+        ///     An exception occcured in <see cref="ModuleBase{TContext}.BeforeExecutedAsync()"/>.
         /// </summary>
         BeforeExecuted,
 

--- a/src/Qmmands/Results/Failed/Execution/CommandExecutionStep.cs
+++ b/src/Qmmands/Results/Failed/Execution/CommandExecutionStep.cs
@@ -20,6 +20,12 @@
         /// </summary>
         TypeParsing,
 
+
+        /// <summary>
+        ///     An exception occurred during generating the cooldown bucket key using <see cref="CommandService.CooldownBucketKeyGenerator"/>.
+        /// </summary>
+        CooldownBucketKeyGenerating,
+
         /// <summary>
         ///     An exception occcured in <see cref="ModuleBase{TContext}.BeforeExecutedAsync()"/>.
         /// </summary>

--- a/src/Qmmands/Results/Failed/Execution/CommandExecutionStep.cs
+++ b/src/Qmmands/Results/Failed/Execution/CommandExecutionStep.cs
@@ -20,7 +20,6 @@
         /// </summary>
         TypeParsing,
 
-
         /// <summary>
         ///     An exception occurred during generating the cooldown bucket key using <see cref="CommandService.CooldownBucketKeyGenerator"/>.
         /// </summary>

--- a/src/Qmmands/Results/Failed/Execution/CommandExecutionStep.cs
+++ b/src/Qmmands/Results/Failed/Execution/CommandExecutionStep.cs
@@ -11,7 +11,7 @@
         Checks,
 
         /// <summary>
-        ///     An exception occurred in <see cref="IArgumentParser.ParseRawArguments"/> during raw argument parsing.
+        ///     An exception occurred in <see cref="IArgumentParser.Parse"/> during raw argument parsing.
         /// </summary>
         ArgumentParsing,
 

--- a/src/Qmmands/Results/Failed/Execution/ExecutionFailedResult.cs
+++ b/src/Qmmands/Results/Failed/Execution/ExecutionFailedResult.cs
@@ -8,7 +8,9 @@ namespace Qmmands
     /// </summary>
     public sealed class ExecutionFailedResult : FailedResult
     {
-        /// <inheritdoc />
+        /// <summary>
+        ///     Gets the reason of this failed result.
+        /// </summary>s
         public override string Reason { get; }
 
         /// <summary>

--- a/src/Qmmands/Results/Failed/OverloadsFailedResult.cs
+++ b/src/Qmmands/Results/Failed/OverloadsFailedResult.cs
@@ -7,7 +7,9 @@ namespace Qmmands
     /// </summary>
     public sealed class OverloadsFailedResult : FailedResult
     {
-        /// <inheritdoc />
+        /// <summary>
+        ///     Gets the reason of this failed result.
+        /// </summary>s
         public override string Reason => "Failed to find a matching overload.";
 
         /// <summary>

--- a/src/Qmmands/Results/Failed/Parsing/ArgumentParseFailedResult.cs
+++ b/src/Qmmands/Results/Failed/Parsing/ArgumentParseFailedResult.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -26,7 +26,7 @@ namespace Qmmands
         public Parameter Parameter { get; }
 
         /// <summary>
-        ///     Gets the raw arguments passed to the <see cref="IArgumentParser.ParseRawArguments"/>.
+        ///     Gets the raw arguments passed to the <see cref="IArgumentParser.Parse"/>.
         /// </summary>
         public string RawArguments { get; }
 

--- a/src/Qmmands/Results/Failed/Parsing/ArgumentParseFailedResult.cs
+++ b/src/Qmmands/Results/Failed/Parsing/ArgumentParseFailedResult.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -10,7 +10,9 @@ namespace Qmmands
     /// </summary>
     public sealed class ArgumentParseFailedResult : FailedResult
     {
-        /// <inheritdoc />
+        /// <summary>
+        ///     Gets the reason of this failed result.
+        /// </summary>
         public override string Reason { get; }
 
         /// <summary>

--- a/src/Qmmands/Results/Failed/TypeParseFailedResult.cs
+++ b/src/Qmmands/Results/Failed/TypeParseFailedResult.cs
@@ -5,7 +5,9 @@
     /// </summary>
     public sealed class TypeParseFailedResult : FailedResult
     {
-        /// <inheritdoc />
+        /// <summary>
+        ///     Gets the reason of this failed result.
+        /// </summary>
         public override string Reason { get; }
 
         /// <summary>

--- a/src/Qmmands/Results/User/ArgumentParser/ArgumentParserResult.cs
+++ b/src/Qmmands/Results/User/ArgumentParser/ArgumentParserResult.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Qmmands
 {
@@ -7,7 +7,9 @@ namespace Qmmands
     /// </summary>
     public struct ArgumentParserResult : IResult
     {
-        /// <inheritdoc />
+        /// <summary>
+        ///     Gets whether the result was successful or not.
+        /// </summary>
         public bool IsSuccessful => ArgumentParserFailure == null;
 
         /// <summary>

--- a/src/Qmmands/Results/User/ArgumentParser/ArgumentParserResult.cs
+++ b/src/Qmmands/Results/User/ArgumentParser/ArgumentParserResult.cs
@@ -1,9 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Qmmands
 {
     /// <summary>
-    ///     Represents an <see cref="IArgumentParser.ParseRawArguments"/> result.
+    ///     Represents an <see cref="IArgumentParser.Parse"/> result.
     /// </summary>
     public struct ArgumentParserResult : IResult
     {
@@ -24,7 +24,7 @@ namespace Qmmands
         public Parameter Parameter { get; }
 
         /// <summary>
-        ///     Gets the raw arguments passed to the <see cref="IArgumentParser.ParseRawArguments"/>.
+        ///     Gets the raw arguments passed to the <see cref="IArgumentParser.Parse"/>.
         /// </summary>
         public string RawArguments { get; }
 

--- a/src/Qmmands/Results/User/ArgumentParser/ArgumentParserResult.cs
+++ b/src/Qmmands/Results/User/ArgumentParser/ArgumentParserResult.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Qmmands
 {
@@ -7,6 +8,9 @@ namespace Qmmands
     /// </summary>
     public struct ArgumentParserResult : IResult
     {
+        private static readonly IReadOnlyDictionary<Parameter, object> _emptyParameterDictionary =
+            new ReadOnlyDictionary<Parameter, object>(new Dictionary<Parameter, object>(0));
+
         /// <summary>
         ///     Gets whether the result was successful or not.
         /// </summary>
@@ -57,7 +61,7 @@ namespace Qmmands
             Command = command;
             Parameter = parameter;
             RawArguments = rawArguments;
-            Arguments = arguments;
+            Arguments = arguments ?? _emptyParameterDictionary;
             ArgumentParserFailure = parseFailure;
             FailurePosition = failurePosition;
         }
@@ -72,7 +76,7 @@ namespace Qmmands
         {
             Command = command;
             RawArguments = rawArguments;
-            Arguments = arguments;
+            Arguments = arguments ?? _emptyParameterDictionary;
         }
     }
 }

--- a/src/Qmmands/Results/User/CheckResult.cs
+++ b/src/Qmmands/Results/User/CheckResult.cs
@@ -5,7 +5,9 @@
     /// </summary>
     public class CheckResult : IResult
     {
-        /// <inheritdoc />
+        /// <summary>
+        ///     Gets whether the result was successful or not.
+        /// </summary>
         public virtual bool IsSuccessful => Reason == null;
 
         /// <summary>
@@ -29,7 +31,7 @@
         /// <summary>
         ///     Gets a successful <see cref="CheckResult"/>.
         /// </summary>
-        public static CheckResult Successful 
+        public static CheckResult Successful
             => new CheckResult();
 
         /// <summary>

--- a/src/Qmmands/Results/User/CheckResult.cs
+++ b/src/Qmmands/Results/User/CheckResult.cs
@@ -1,7 +1,7 @@
 ﻿namespace Qmmands
 {
     /// <summary>
-    ///     Represents a <see cref="CheckBaseAttribute"/>'s result.
+    ///     Represents a <see cref="CheckAttribute"/>'s result.
     /// </summary>
     public class CheckResult : IResult
     {

--- a/src/Qmmands/Results/User/CheckResult.cs
+++ b/src/Qmmands/Results/User/CheckResult.cs
@@ -43,5 +43,14 @@
         /// </returns>
         public static CheckResult Unsuccessful(string reason)
             => new CheckResult(reason);
+
+#if NETCOREAPP
+        /// <summary>
+        ///     Implicitly wraps the provided <see cref="CheckResult"/> in <see cref="System.Threading.Tasks.ValueTask{TResult}"/>.
+        /// </summary>
+        /// <param name="result"></param>
+        public static implicit operator System.Threading.Tasks.ValueTask<CheckResult>(CheckResult result)
+            => new System.Threading.Tasks.ValueTask<CheckResult>(result);
+#endif
     }
 }

--- a/src/Qmmands/Results/User/CommandResult.cs
+++ b/src/Qmmands/Results/User/CommandResult.cs
@@ -14,5 +14,14 @@
         ///     The <see cref="Qmmands.Command"/> this result was returned by.
         /// </summary>
         public Command Command { get; internal set; }
+
+#if NETCOREAPP
+        /// <summary>
+        ///     Implicitly wraps the provided <see cref="CommandResult"/> in <see cref="System.Threading.Tasks.ValueTask{TResult}"/>.
+        /// </summary>
+        /// <param name="result"></param>
+        public static implicit operator System.Threading.Tasks.ValueTask<CommandResult>(CommandResult result)
+            => new System.Threading.Tasks.ValueTask<CommandResult>(result);
+#endif
     }
 }

--- a/src/Qmmands/Results/User/CommandResult.cs
+++ b/src/Qmmands/Results/User/CommandResult.cs
@@ -5,7 +5,9 @@
     /// </summary>
     public abstract class CommandResult : IResult
     {
-        /// <inheritdoc />
+        /// <summary>
+        ///     Gets whether the result was successful or not.
+        /// </summary>
         public abstract bool IsSuccessful { get; }
 
         /// <summary>

--- a/src/Qmmands/Results/User/TypeParserResult.cs
+++ b/src/Qmmands/Results/User/TypeParserResult.cs
@@ -65,5 +65,14 @@
         /// </returns>
         public static TypeParserResult<T> Unsuccessful(string reason)
             => new TypeParserResult<T>(reason);
+
+#if NETCOREAPP
+        /// <summary>
+        ///     Implicitly wraps the provided <see cref="TypeParserResult{T}"/> in <see cref="System.Threading.Tasks.ValueTask{TResult}"/>.
+        /// </summary>
+        /// <param name="result"></param>
+        public static implicit operator System.Threading.Tasks.ValueTask<TypeParserResult<T>>(TypeParserResult<T> result)
+            => new System.Threading.Tasks.ValueTask<TypeParserResult<T>>(result);
+#endif
     }
 }

--- a/src/Qmmands/Results/User/TypeParserResult.cs
+++ b/src/Qmmands/Results/User/TypeParserResult.cs
@@ -6,11 +6,13 @@
     /// <typeparam name="T"> The type handled by the type parser. </typeparam>
     public sealed class TypeParserResult<T> : IResult
     {
-        /// <inheritdoc />
+        /// <summary>
+        ///     Gets whether the result was successful or not.
+        /// </summary>
         public bool IsSuccessful => Reason == null;
 
         /// <summary>
-        ///     Gets the error reason. Null if <see cref="IsSuccessful"/> is <see langword="true"/>.
+        ///     Gets the error reason. <see langword="null"/> if <see cref="IsSuccessful"/> is <see langword="true"/>.
         /// </summary>
         public string Reason { get; }
 


### PR DESCRIPTION
- The overall performance has been improved.
- The framework now additionally targets .NET Core 2.1 and 2.2 which adds:
   - Span usage in the `CommandUtilities`, command mapping, default argument parser, and primitive type parsers further improving the performance
   - `CheckAttribute`, `ParameterCheckAttribute` and `TypeParser<>` expose `ValueTask<>` instead of `Task<>` removing unnecessary task allocations. Implicit conversion to `ValueTask<>` for result types is provided
   - `ValueTask<T> where T : CommandResult` is supported for commands. `CommandResult` also has implicit conversion to `ValueTask<>`
- `OverrideTypeParserAttribute` is now extendable
 - `ICommandContext` has been replaced with `CommandContext` which is an abstract class that exposes `CommandMatch`'s properties and parsed arguments
 - Added the missing `CommandExecutionStep.CooldownBucketKeyGenerating` for accurate error handling
 - Empty strings can now be used as aliases to make the command/group use its parent's aliases as its own or bypass its parent's aliases
 - Removed 'Base' from checks' names
 - Made builder constructors internal, builders' parents are now accessible
 - Fixed various naming and docs inconsistencies
 - Changed `IArgumentParser#ParseRawArguments(Command command, string rawArguments)` to `IArgumentParser#Parse(CommandContext context)`
 - Added `CommandService#RemoveAllTypeParsers()`