### PR TITLE
Implement support for .NET Standard 2.0

### DIFF
--- a/src/Qmmands/Builders/CommandBuilder.cs
+++ b/src/Qmmands/Builders/CommandBuilder.cs
@@ -97,7 +97,14 @@ namespace Qmmands
             Module = module;
             Callback = callback;
             Cooldowns = new List<Cooldown>();
+
+            #if NETSTANDARD2_0
+            Aliases = new HashSet<string>();
+            #else
             Aliases = new HashSet<string>(1);
+            #endif
+
+
             Checks = new List<CheckAttribute>();
             Attributes = new List<Attribute>();
             Parameters = new List<ParameterBuilder>();

--- a/src/Qmmands/CommandService.cs
+++ b/src/Qmmands/CommandService.cs
@@ -124,7 +124,11 @@ namespace Qmmands
                 ? configuration.NullableNouns.ToImmutableArray()
                 : CommandUtilities.DefaultNullableNouns;
 
+            #if NETSTANDARD2_0
+            StringComparer = StringComparerExtensions.FromComparison(StringComparison);
+            #else
             StringComparer = StringComparer.FromComparison(StringComparison);
+            #endif
 
             _topLevelModules = new HashSet<Module>();
             TopLevelModules = new ReadOnlySet<Module>(_topLevelModules);

--- a/src/Qmmands/CommandUtilities.cs
+++ b/src/Qmmands/CommandUtilities.cs
@@ -496,7 +496,7 @@ namespace Qmmands
             if (prefix == null)
                 throw new ArgumentNullException(nameof(prefix), "The prefix must not be null.");
 
-            if (!input.StartsWith(prefix, comparison))
+            if (!input.StartsWith(prefix.AsSpan(), comparison))
             {
                 output = null;
                 return false;

--- a/src/Qmmands/CommandUtilities.cs
+++ b/src/Qmmands/CommandUtilities.cs
@@ -21,7 +21,7 @@ namespace Qmmands
         public static readonly IReadOnlyList<string> DefaultNullableNouns;
 
         /// <summary>
-        ///     The friendly names used for primitive <see cref="Type"/>s by <see cref="ArgumentParseFailedResult.Reason"/>. 
+        ///     The friendly names used for primitive <see cref="Type"/>s by <see cref="ArgumentParseFailedResult.Reason"/>.
         /// </summary>
         public static readonly IReadOnlyDictionary<Type, string> FriendlyPrimitiveTypeNames;
 
@@ -354,7 +354,7 @@ namespace Qmmands
                 return false;
             }
 
-            output = new string(input.Slice(1).TrimStart());
+            output = input.Slice(1).TrimStart().ToString();
             return true;
         }
 
@@ -502,7 +502,7 @@ namespace Qmmands
                 return false;
             }
 
-            output = new string(input.Slice(prefix.Length).TrimStart());
+            output = input.Slice(prefix.Length).TrimStart().ToString();
             return true;
         }
 

--- a/src/Qmmands/Extensions/StringComparerExtensions.cs
+++ b/src/Qmmands/Extensions/StringComparerExtensions.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Qmmands
+{
+    /// <summary>
+    ///     Defines extensions for the <see cref="StringComparer"/> class.
+    /// </summary>
+    public class StringComparerExtensions
+    {
+        #if NETSTANDARD2_0
+        /// <summary>
+        ///     Converts a <see cref="StringComparison"/> value to its corresponding <see cref="StringComparer"/>.
+        /// </summary>
+        /// <param name="comparison">The comparision.</param>
+        /// <returns>The comparer.</returns>
+        public static StringComparer FromComparison(StringComparison comparison)
+        {
+            return comparison switch
+            {
+                StringComparison.CurrentCulture => StringComparer.CurrentCulture,
+                StringComparison.CurrentCultureIgnoreCase => StringComparer.CurrentCultureIgnoreCase,
+                StringComparison.InvariantCulture => StringComparer.InvariantCulture,
+                StringComparison.InvariantCultureIgnoreCase => StringComparer.InvariantCultureIgnoreCase,
+                StringComparison.Ordinal => StringComparer.Ordinal,
+                StringComparison.OrdinalIgnoreCase => StringComparer.OrdinalIgnoreCase,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+        #endif
+    }
+}

--- a/src/Qmmands/Mapping/CommandMap.cs
+++ b/src/Qmmands/Mapping/CommandMap.cs
@@ -15,7 +15,7 @@ namespace Qmmands
         public IReadOnlyList<CommandMatch> FindCommands(string text)
         {
             List<CommandMatch> matches = null;
-            _rootNode.FindCommands(ref matches, new List<string>(), text);
+            _rootNode.FindCommands(ref matches, new List<string>(), text.AsSpan());
             return matches ?? Array.Empty<CommandMatch>() as IReadOnlyList<CommandMatch>;
         }
 

--- a/src/Qmmands/Mapping/CommandMapNode.cs
+++ b/src/Qmmands/Mapping/CommandMapNode.cs
@@ -91,7 +91,7 @@ namespace Qmmands
             var separator = _service.Separator;
             var separatorIndex = _isSeparatorSingleWhitespace
                 ? -1
-                : span.IndexOf(separator, _service.StringComparison);
+                : span.IndexOf(separator.AsSpan(), _service.StringComparison);
             for (var i = 0; i < span.Length; i++)
             {
                 if (segmentIndex != 0)

--- a/src/Qmmands/Mapping/CommandMapNode.cs
+++ b/src/Qmmands/Mapping/CommandMapNode.cs
@@ -30,14 +30,14 @@ namespace Qmmands
             if (encounteredSeparator && remaining.IsEmpty)
                 return;
 
-            var stringSegment = new string(segment);
+            var stringSegment = segment.ToString();
             if (!encounteredSeparator && !(encounteredWhitespace && remaining.IsEmpty) && _commands.TryGetValue(stringSegment, out var commands))
             {
                 path.Add(stringSegment);
 
                 var stringRemaining = remaining.IsEmpty
                     ? string.Empty
-                    : new string(remaining);
+                    : remaining.ToString();
 
                 if (matches == null)
                     matches = new List<CommandMatch>(commands.Count);

--- a/src/Qmmands/Parsing/ArgumentParsers/Default/DefaultArgumentParser.cs
+++ b/src/Qmmands/Parsing/ArgumentParsers/Default/DefaultArgumentParser.cs
@@ -79,7 +79,12 @@ namespace Qmmands
 
                 if (currentParameter.IsRemainder)
                 {
+                    #if NETSTANDARD2_0
+                    argumentBuilder.Append(rawArguments.Slice(currentPosition).ToString());
+                    #else
                     argumentBuilder.Append(rawArguments.Slice(currentPosition));
+                    #endif
+
                     break;
                 }
 

--- a/src/Qmmands/Parsing/TypeParsers/Primitive/EnumTypeParser.cs
+++ b/src/Qmmands/Parsing/TypeParsers/Primitive/EnumTypeParser.cs
@@ -29,6 +29,6 @@ namespace Qmmands
         }
 
         public bool TryParse(Parameter parameter, string value, out object result)
-            => _tryParse(value, out var numericResult) ? _enumByValues.TryGetValue(numericResult, out result) : _enumByNames.TryGetValue(value, out result);
+            => _tryParse(value.AsSpan(), out var numericResult) ? _enumByValues.TryGetValue(numericResult, out result) : _enumByNames.TryGetValue(value, out result);
     }
 }

--- a/src/Qmmands/Parsing/TypeParsers/Primitive/PrimitiveTypeParser.cs
+++ b/src/Qmmands/Parsing/TypeParsers/Primitive/PrimitiveTypeParser.cs
@@ -1,4 +1,5 @@
-﻿using Qmmands.Delegates;
+﻿using System;
+using Qmmands.Delegates;
 
 namespace Qmmands
 {
@@ -13,7 +14,7 @@ namespace Qmmands
         }
 
         public bool TryParse(string value, out T result)
-            => _tryParse(value, out result);
+            => _tryParse(value.AsSpan(), out result);
 
         bool IPrimitiveTypeParser.TryParse(Parameter parameter, string value, out object result)
         {

--- a/src/Qmmands/Qmmands.csproj
+++ b/src/Qmmands/Qmmands.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <VersionPrefix>3.1.3</VersionPrefix>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Quahu</Authors>
@@ -16,5 +16,9 @@
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="Qommon" Version="1.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 </Project>

--- a/src/Qmmands/Results/Failed/Parsing/TypeParseFailedResult.cs
+++ b/src/Qmmands/Results/Failed/Parsing/TypeParseFailedResult.cs
@@ -30,7 +30,7 @@ namespace Qmmands
 
             if (reason != null)
             {
-                _lazyReason = new Lazy<string>(reason);
+                _lazyReason = new Lazy<string>(() => reason);
                 return;
             }
 

--- a/src/Qmmands/Utilities.cs
+++ b/src/Qmmands/Utilities.cs
@@ -506,6 +506,24 @@ namespace Qmmands
 
         static Utilities()
         {
+            #if NETSTANDARD2_0
+            TryParseDelegates = new Dictionary<Type, Delegate>(13)
+            {
+                [typeof(char)] = (TryParseDelegate<char>) TryParseChar,
+                [typeof(bool)] = (TryParseDelegate<bool>) TryParseBool,
+                [typeof(byte)] = (TryParseDelegate<byte>) TryParseByte,
+                [typeof(sbyte)] = (TryParseDelegate<sbyte>) TryParseSByte,
+                [typeof(short)] = (TryParseDelegate<short>) TryParseShort,
+                [typeof(ushort)] = (TryParseDelegate<ushort>) TryParseUShort,
+                [typeof(int)] = (TryParseDelegate<int>) TryParseInt,
+                [typeof(uint)] = (TryParseDelegate<uint>) TryParseUInt,
+                [typeof(long)] = (TryParseDelegate<long>) TryParseLong,
+                [typeof(ulong)] = (TryParseDelegate<ulong>) TryParseULong,
+                [typeof(float)] = (TryParseDelegate<float>) TryParseFloat,
+                [typeof(double)] = (TryParseDelegate<double>) TryParseDouble,
+                [typeof(decimal)] = (TryParseDelegate<decimal>) TryParseDecimal
+            };
+            #else
             TryParseDelegates = new Dictionary<Type, Delegate>(13)
             {
                 [typeof(char)] = (TryParseDelegate<char>) TryParseChar,
@@ -522,7 +540,46 @@ namespace Qmmands
                 [typeof(double)] = (TryParseDelegate<double>) double.TryParse,
                 [typeof(decimal)] = (TryParseDelegate<decimal>) decimal.TryParse
             };
+            #endif
         }
+
+        #if  NETSTANDARD2_0
+        private static bool TryParseBool(ReadOnlySpan<char> span, out bool result) =>
+            bool.TryParse(span.ToString(), out result);
+
+        private static bool TryParseByte(ReadOnlySpan<char> span, out byte result) =>
+            byte.TryParse(span.ToString(), out result);
+
+        private static bool TryParseSByte(ReadOnlySpan<char> span, out sbyte result) =>
+            sbyte.TryParse(span.ToString(), out result);
+
+        private static bool TryParseShort(ReadOnlySpan<char> span, out short result) =>
+            short.TryParse(span.ToString(), out result);
+
+        private static bool TryParseUShort(ReadOnlySpan<char> span, out ushort result) =>
+            ushort.TryParse(span.ToString(), out result);
+
+        private static bool TryParseInt(ReadOnlySpan<char> span, out int result) =>
+            int.TryParse(span.ToString(), out result);
+
+        private static bool TryParseUInt(ReadOnlySpan<char> span, out uint result) =>
+            uint.TryParse(span.ToString(), out result);
+
+        private static bool TryParseLong(ReadOnlySpan<char> span, out long result) =>
+            long.TryParse(span.ToString(), out result);
+
+        private static bool TryParseULong(ReadOnlySpan<char> span, out ulong result) =>
+            ulong.TryParse(span.ToString(), out result);
+
+        private static bool TryParseFloat(ReadOnlySpan<char> span, out float result) =>
+            float.TryParse(span.ToString(), out result);
+
+        private static bool TryParseDouble(ReadOnlySpan<char> span, out double result) =>
+            double.TryParse(span.ToString(), out result);
+
+        private static bool TryParseDecimal(ReadOnlySpan<char> span, out decimal result) =>
+            decimal.TryParse(span.ToString(), out result);
+        #endif
 
         private static bool TryParseChar(ReadOnlySpan<char> value, out char result)
         {


### PR DESCRIPTION
Many libraries are still using .NET Standard 2.0, and it would be quite useful for them to be able to consume this library.

This PR implements support for .NET Standard 2.0 in the library, utilizing some minor compile-time preprocessing to ensure that .NET Core targets don't lose any performance because of these changes.

If you merge this pull request, I'd also appreciate it if you tagged it as "hacktoberfest-accepted", so that it counts towards a t-shirt :P